### PR TITLE
fix(ui): button focus border visibility and section scroll

### DIFF
--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -60,22 +60,22 @@
                                                 <Setter Property="Template">
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="Button">
-                                                            <Border Background="{TemplateBinding Background}" 
-                                                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                            <Border x:Name="ButtonBorder"
+                                                                    Background="{TemplateBinding Background}" 
+                                                                    BorderBrush="Transparent"
+                                                                    BorderThickness="2"
                                                                     CornerRadius="5" Padding="{TemplateBinding Padding}">
                                                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                             </Border>
                                                             <ControlTemplate.Triggers>
                                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="#4A4A4A"/>
+                                                                    <Setter TargetName="ButtonBorder" Property="Background" Value="#4A4A4A"/>
                                                                 </Trigger>
                                                                 <Trigger Property="IsPressed" Value="True">
-                                                                    <Setter Property="Background" Value="#2A2A2A"/>
+                                                                    <Setter TargetName="ButtonBorder" Property="Background" Value="#2A2A2A"/>
                                                                 </Trigger>
                                                                 <Trigger Property="IsFocused" Value="True">
-                                                                    <Setter Property="BorderBrush" Value="#FFFFFF"/>
-                                                                    <Setter Property="BorderThickness" Value="2"/>
+                                                                    <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#FFFFFF"/>
                                                                 </Trigger>
                                                             </ControlTemplate.Triggers>
                                                         </ControlTemplate>
@@ -93,22 +93,22 @@
                                                 <Setter Property="Template">
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="Button">
-                                                            <Border Background="{TemplateBinding Background}" 
-                                                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                            <Border x:Name="ButtonBorder"
+                                                                    Background="{TemplateBinding Background}" 
+                                                                    BorderBrush="Transparent"
+                                                                    BorderThickness="2"
                                                                     CornerRadius="5" Padding="{TemplateBinding Padding}">
                                                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                             </Border>
                                                             <ControlTemplate.Triggers>
                                                                 <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="#E53935"/>
+                                                                    <Setter TargetName="ButtonBorder" Property="Background" Value="#E53935"/>
                                                                 </Trigger>
                                                                 <Trigger Property="IsPressed" Value="True">
-                                                                    <Setter Property="Background" Value="#C62828"/>
+                                                                    <Setter TargetName="ButtonBorder" Property="Background" Value="#C62828"/>
                                                                 </Trigger>
                                                                 <Trigger Property="IsFocused" Value="True">
-                                                                    <Setter Property="BorderBrush" Value="#FFFFFF"/>
-                                                                    <Setter Property="BorderThickness" Value="2"/>
+                                                                    <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#FFFFFF"/>
                                                                 </Trigger>
                                                             </ControlTemplate.Triggers>
                                                         </ControlTemplate>
@@ -200,22 +200,22 @@
                                                         <Setter Property="Template">
                                                             <Setter.Value>
                                                                 <ControlTemplate TargetType="Button">
-                                                                    <Border Background="{TemplateBinding Background}" 
-                                                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                                                    <Border x:Name="ButtonBorder"
+                                                                            Background="{TemplateBinding Background}" 
+                                                                            BorderBrush="Transparent"
+                                                                            BorderThickness="2"
                                                                             CornerRadius="5" Padding="{TemplateBinding Padding}">
                                                                         <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                                     </Border>
                                                                     <ControlTemplate.Triggers>
                                                                         <Trigger Property="IsMouseOver" Value="True">
-                                                                            <Setter Property="Background" Value="#7D5FDB"/>
+                                                                            <Setter TargetName="ButtonBorder" Property="Background" Value="#7D5FDB"/>
                                                                         </Trigger>
                                                                         <Trigger Property="IsPressed" Value="True">
-                                                                            <Setter Property="Background" Value="#5A3FB5"/>
+                                                                            <Setter TargetName="ButtonBorder" Property="Background" Value="#5A3FB5"/>
                                                                         </Trigger>
                                                                         <Trigger Property="IsFocused" Value="True">
-                                                                            <Setter Property="BorderBrush" Value="#FFFFFF"/>
-                                                                            <Setter Property="BorderThickness" Value="2"/>
+                                                                            <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#FFFFFF"/>
                                                                         </Trigger>
                                                                     </ControlTemplate.Triggers>
                                                                 </ControlTemplate>
@@ -334,22 +334,22 @@
                                                     <Setter Property="Template">
                                                         <Setter.Value>
                                                             <ControlTemplate TargetType="Button">
-                                                                <Border Background="{TemplateBinding Background}" 
-                                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                                                <Border x:Name="ButtonBorder"
+                                                                        Background="{TemplateBinding Background}" 
+                                                                        BorderBrush="Transparent"
+                                                                        BorderThickness="2"
                                                                         CornerRadius="5" Padding="{TemplateBinding Padding}">
                                                                     <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                                 </Border>
                                                                 <ControlTemplate.Triggers>
                                                                     <Trigger Property="IsMouseOver" Value="True">
-                                                                        <Setter Property="Background" Value="#5BA3F5"/>
+                                                                        <Setter TargetName="ButtonBorder" Property="Background" Value="#5BA3F5"/>
                                                                     </Trigger>
                                                                     <Trigger Property="IsPressed" Value="True">
-                                                                        <Setter Property="Background" Value="#3A7BC8"/>
+                                                                        <Setter TargetName="ButtonBorder" Property="Background" Value="#3A7BC8"/>
                                                                     </Trigger>
                                                                     <Trigger Property="IsFocused" Value="True">
-                                                                        <Setter Property="BorderBrush" Value="#FFFFFF"/>
-                                                                        <Setter Property="BorderThickness" Value="2"/>
+                                                                        <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#FFFFFF"/>
                                                                     </Trigger>
                                                                 </ControlTemplate.Triggers>
                                                             </ControlTemplate>

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -560,7 +560,7 @@ public partial class OverlayWindow : Window
 
         navigationTarget = NavigationTarget.SwitchButton;
         SwitchBtn.Focus();
-        SwitchBtn.BringIntoView();
+        CurrentGameSection.BringIntoView();
     }
 
     private void FocusExitButton()
@@ -577,7 +577,7 @@ public partial class OverlayWindow : Window
 
         navigationTarget = NavigationTarget.ExitButton;
         ExitBtn.Focus();
-        ExitBtn.BringIntoView();
+        CurrentGameSection.BringIntoView();
     }
 
     private void FocusRunningAppItem(int index)


### PR DESCRIPTION
## Summary

- Fixed button focus border not appearing when navigating with keyboard/controller
- Fixed CurrentGameSection being clipped when navigating back to buttons

## Changes

### Button Focus Border Fix
The `IsFocused` trigger was setting properties on the Button, but the Border inside the ControlTemplate was using `{TemplateBinding}` which doesn't update dynamically from triggers.

**Fix:** 
- Added `x:Name="ButtonBorder"` to the Border element in each button's ControlTemplate
- Changed triggers to use `TargetName="ButtonBorder"` to directly target the Border
- Set fixed `BorderThickness="2"` with `BorderBrush="Transparent"` by default, switching to white on focus

### Section Scroll Fix
When navigating back to SwitchBtn or ExitBtn, only the button was scrolled into view, cutting off the cover image and title.

**Fix:**
- Changed `BringIntoView()` calls in `FocusSwitchButton()` and `FocusExitButton()` to target `CurrentGameSection` instead of the button itself

## Testing
- [ ] White border appears on buttons when focused with keyboard/controller
- [ ] Full CurrentGameSection visible when navigating back to buttons
- [ ] Border disappears when focus moves away