### PR TITLE
fix(ui): clear button focus when exiting to section level

### DIFF
--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -252,6 +252,9 @@ public partial class OverlayWindow : Window
         RunningAppsList.SelectedIndex = -1;
         RecentList.SelectedIndex = -1;
         
+        // Remove focus from any button to hide its focus border
+        Keyboard.Focus(this);
+        
         // Clear all section highlights
         ClearSectionHighlights();
         


### PR DESCRIPTION
## Summary
- Fixes button highlight persisting when pressing Escape/B to exit from item-level (button) to section-level
- Adds `Keyboard.Focus(this)` in `FocusSection()` to move focus away from buttons

## Problem
When inside CurrentGameSection at item-level (focused on SwitchBtn or ExitBtn), pressing Escape would:
1. Exit to section-level correctly
2. Show section border correctly
3. **But keep the button's white border visible** because the button retained `IsFocused=True`

## Solution
Call `Keyboard.Focus(this)` before setting section highlights to remove focus from any button, which removes its `IsFocused` state and hides its white border.