### PR TITLE
fix: use XInputGetStateEx for proper Guide button detection

### DIFF
--- a/src/OverlayPlugin/Interop/XInput.cs
+++ b/src/OverlayPlugin/Interop/XInput.cs
@@ -36,21 +36,86 @@ internal static class XInput
     public const ushort XINPUT_GAMEPAD_RIGHT_THUMB = 0x0080;
     public const ushort XINPUT_GAMEPAD_LEFT_SHOULDER = 0x0100;
     public const ushort XINPUT_GAMEPAD_RIGHT_SHOULDER = 0x0200;
+    // Guide button - undocumented, only available via XInputGetStateEx (ordinal 100)
+    public const ushort XINPUT_GAMEPAD_GUIDE = 0x0400;
     public const ushort XINPUT_GAMEPAD_A = 0x1000;
     public const ushort XINPUT_GAMEPAD_B = 0x2000;
     public const ushort XINPUT_GAMEPAD_X = 0x4000;
     public const ushort XINPUT_GAMEPAD_Y = 0x8000;
 
+    // ========== Standard XInputGetState (Guide button masked out) ==========
     [DllImport("xinput1_4.dll", EntryPoint = "XInputGetState")]
     private static extern int XInputGetState1_4(int dwUserIndex, out XINPUT_STATE pState);
 
-    // Fallback to older DLLs if needed
     [DllImport("xinput1_3.dll", EntryPoint = "XInputGetState")]
     private static extern int XInputGetState1_3(int dwUserIndex, out XINPUT_STATE pState);
 
     [DllImport("xinput9_1_0.dll", EntryPoint = "XInputGetState")]
     private static extern int XInputGetState9_1_0(int dwUserIndex, out XINPUT_STATE pState);
 
+    // ========== XInputGetStateEx (ordinal 100) - includes Guide button ==========
+    // This is an undocumented API exported by ordinal, not by name.
+    // We need to load it dynamically using GetProcAddress.
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr LoadLibrary(string lpFileName);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GetProcAddress(IntPtr hModule, IntPtr ordinal);
+
+    private delegate int XInputGetStateExDelegate(int dwUserIndex, out XINPUT_STATE pState);
+    private static XInputGetStateExDelegate? _xInputGetStateEx;
+    private static bool _initialized;
+    private static bool _guideButtonSupported;
+
+    /// <summary>
+    /// Whether the Guide button is supported (XInputGetStateEx ordinal 100 was found).
+    /// </summary>
+    public static bool GuideButtonSupported
+    {
+        get
+        {
+            EnsureInitialized();
+            return _guideButtonSupported;
+        }
+    }
+
+    private static void EnsureInitialized()
+    {
+        if (_initialized) return;
+        _initialized = true;
+
+        // Try to load xinput1_4.dll first (Windows 8+), then fall back to xinput1_3.dll
+        IntPtr xinputHandle = LoadLibrary("xinput1_4.dll");
+        if (xinputHandle == IntPtr.Zero)
+        {
+            xinputHandle = LoadLibrary("xinput1_3.dll");
+        }
+
+        if (xinputHandle == IntPtr.Zero)
+        {
+            _guideButtonSupported = false;
+            return;
+        }
+
+        // Load XInputGetStateEx by ordinal 100
+        // This undocumented function is the same as XInputGetState but doesn't mask out the Guide button
+        IntPtr procAddress = GetProcAddress(xinputHandle, (IntPtr)100);
+        if (procAddress != IntPtr.Zero)
+        {
+            _xInputGetStateEx = Marshal.GetDelegateForFunctionPointer<XInputGetStateExDelegate>(procAddress);
+            _guideButtonSupported = true;
+        }
+        else
+        {
+            _guideButtonSupported = false;
+        }
+    }
+
+    /// <summary>
+    /// Gets controller state using the standard XInputGetState API.
+    /// Note: Guide button is masked out in this API.
+    /// </summary>
     public static bool TryGetState(int userIndex, out XINPUT_STATE state)
     {
         try
@@ -79,7 +144,36 @@ internal static class XInput
         return false;
     }
 
+    /// <summary>
+    /// Gets controller state using XInputGetStateEx (ordinal 100).
+    /// This includes the Guide button in wButtons (bit 0x0400).
+    /// Falls back to standard XInputGetState if ordinal 100 is not available.
+    /// </summary>
+    public static bool TryGetStateEx(int userIndex, out XINPUT_STATE state)
+    {
+        EnsureInitialized();
+
+        if (_xInputGetStateEx != null)
+        {
+            try
+            {
+                if (_xInputGetStateEx(userIndex, out state) == ERROR_SUCCESS)
+                    return true;
+            }
+            catch
+            {
+                // Fall through to standard API
+            }
+        }
+
+        // Fall back to standard API (Guide button won't be available)
+        return TryGetState(userIndex, out state);
+    }
+
     // ========== Keystroke APIs ==========
+    // Note: XInputGetKeystroke does NOT report Guide button events.
+    // Use TryGetStateEx and check XINPUT_GAMEPAD_GUIDE bit instead.
+
     [StructLayout(LayoutKind.Sequential)]
     public struct XINPUT_KEYSTROKE
     {
@@ -94,10 +188,23 @@ internal static class XInput
     public const ushort XINPUT_KEYSTROKE_KEYUP = 0x0002;
     public const ushort XINPUT_KEYSTROKE_REPEAT = 0x0004;
 
-    // Common VK_PAD constants subset (values based on widely used headers/community references)
-    public const ushort VK_PAD_GUIDE_BUTTON = 0x0400;
+    // VK_PAD constants for XInputGetKeystroke (NOT for Guide button!)
+    public const ushort VK_PAD_A = 0x5800;
+    public const ushort VK_PAD_B = 0x5801;
+    public const ushort VK_PAD_X = 0x5802;
+    public const ushort VK_PAD_Y = 0x5803;
+    public const ushort VK_PAD_RSHOULDER = 0x5804;
+    public const ushort VK_PAD_LSHOULDER = 0x5805;
+    public const ushort VK_PAD_LTRIGGER = 0x5806;
+    public const ushort VK_PAD_RTRIGGER = 0x5807;
+    public const ushort VK_PAD_DPAD_UP = 0x5810;
+    public const ushort VK_PAD_DPAD_DOWN = 0x5811;
+    public const ushort VK_PAD_DPAD_LEFT = 0x5812;
+    public const ushort VK_PAD_DPAD_RIGHT = 0x5813;
     public const ushort VK_PAD_START = 0x5814;
     public const ushort VK_PAD_BACK = 0x5815;
+    public const ushort VK_PAD_LTHUMB_PRESS = 0x5816;
+    public const ushort VK_PAD_RTHUMB_PRESS = 0x5817;
 
     [DllImport("xinput1_4.dll", EntryPoint = "XInputGetKeystroke")]
     private static extern int XInputGetKeystroke1_4(int dwUserIndex, int dwReserved, out XINPUT_KEYSTROKE pKeystroke);

--- a/tests/OverlayPlugin.Tests/ComboMaskTests.cs
+++ b/tests/OverlayPlugin.Tests/ComboMaskTests.cs
@@ -6,6 +6,9 @@ namespace OverlayPlugin.Tests;
 public class ComboMaskTests
 {
     [Theory]
+    [InlineData("Guide", 0x0400)] // XINPUT_GAMEPAD_GUIDE
+    [InlineData("guide", 0x0400)] // Case insensitive
+    [InlineData("GUIDE", 0x0400)]
     [InlineData("START+BACK", 0x0030)] // START (0x10) | BACK (0x20)
     [InlineData("BACK+START", 0x0030)]
     [InlineData("start+back", 0x0030)] // Case insensitive
@@ -22,7 +25,6 @@ public class ComboMaskTests
     [InlineData("")]
     [InlineData("Invalid")]
     [InlineData("A+B")]
-    [InlineData("Guide")]
     [InlineData(null)]
     public void ResolveComboMask_InvalidCombos_ReturnsZero(string? combo)
     {
@@ -39,6 +41,7 @@ internal static class TestHelper
         var upper = combo.ToUpperInvariant();
         return upper switch
         {
+            "GUIDE" => 0x0400, // XINPUT_GAMEPAD_GUIDE
             "START+BACK" or "BACK+START" => (ushort)(0x0010 | 0x0020),
             "LB+RB" or "RB+LB" => (ushort)(0x0100 | 0x0200),
             _ => 0


### PR DESCRIPTION
## Summary

- Fix Xbox Guide button detection by using the undocumented `XInputGetStateEx` API (ordinal 100) instead of `XInputGetKeystroke`
- `XInputGetKeystroke` does not report Guide button events - this is confirmed in Wine source code and by emulator projects

## Technical Details

The previous implementation incorrectly used `XInputGetKeystroke` with `VK_PAD_GUIDE_BUTTON = 0x0400`. This doesn't work because:

1. `XInputGetKeystroke` **never reports Guide button events** - this is by design
2. `0x0400` is a button mask for `wButtons`, not a VK code (VK codes for gamepad are in the `0x58xx` range)

The correct approach (used by Dolphin, RetroArch, Wine, and other projects) is:

1. Load `XInputGetStateEx` via `GetProcAddress(hModule, (IntPtr)100)` - it's exported by ordinal, not name
2. This function is identical to `XInputGetState` but doesn't mask out the Guide button
3. Check `state.Gamepad.wButtons & 0x0400` for Guide button state

## Changes

- `XInput.cs`: Add `TryGetStateEx()` using ordinal 100, with fallback to standard API
- `InputListener.cs`: Use `TryGetStateEx` when checking for Guide button combo
- `ComboMaskTests.cs`: Add test cases for Guide button (0x0400)

## Important Note

Windows Game Bar may intercept the Guide button before the application sees it. Users may need to disable Xbox Game Bar in Windows Settings > Gaming > Xbox Game Bar if the Guide button doesn't work. Alternative combos (Start+Back, LB+RB) always work reliably.

## References

- [Wine xinput implementation](https://source.winehq.org/git/wine.git/blob/HEAD:/dlls/xinput1_3/xinput_main.c) - XInputGetKeystroke doesn't handle Guide
- [Dolphin emulator](https://github.com/dolphin-emu/dolphin) - Uses ordinal 100 for Guide button
- [RetroArch](https://github.com/libretro/RetroArch) - Uses ordinal 100 for Guide button