### PR TITLE
feat(overlay): add optional process suspension while overlay is active

### DIFF
--- a/src/OverlayPlugin/Interop/ProcessSuspender.cs
+++ b/src/OverlayPlugin/Interop/ProcessSuspender.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Runtime.InteropServices;
+using Playnite.SDK;
+
+namespace PlayniteOverlay.Interop;
+
+/// <summary>
+/// Provides process suspension and resumption using Windows NT APIs.
+/// Used to pause game processes while the overlay is active, preventing
+/// them from receiving controller input.
+/// </summary>
+internal static class ProcessSuspender
+{
+    private static readonly ILogger logger = LogManager.GetLogger();
+
+    // NT status code for success
+    private const int STATUS_SUCCESS = 0;
+
+    // Process access rights
+    private const uint PROCESS_SUSPEND_RESUME = 0x0800;
+
+    [DllImport("ntdll.dll", SetLastError = false)]
+    private static extern int NtSuspendProcess(IntPtr processHandle);
+
+    [DllImport("ntdll.dll", SetLastError = false)]
+    private static extern int NtResumeProcess(IntPtr processHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, int dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    /// <summary>
+    /// Suspends all threads of a process.
+    /// </summary>
+    /// <param name="processId">The process ID to suspend</param>
+    /// <returns>True if suspension succeeded, false otherwise</returns>
+    public static bool SuspendProcess(int processId)
+    {
+        if (processId <= 0)
+        {
+            return false;
+        }
+
+        IntPtr processHandle = IntPtr.Zero;
+        try
+        {
+            processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, false, processId);
+            if (processHandle == IntPtr.Zero)
+            {
+                logger.Debug($"Failed to open process {processId} for suspension (access denied or process exited)");
+                return false;
+            }
+
+            int status = NtSuspendProcess(processHandle);
+            if (status == STATUS_SUCCESS)
+            {
+                logger.Info($"Suspended process {processId}");
+                return true;
+            }
+            else
+            {
+                logger.Debug($"NtSuspendProcess failed for process {processId} with status 0x{status:X8}");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Debug(ex, $"Exception while suspending process {processId}");
+            return false;
+        }
+        finally
+        {
+            if (processHandle != IntPtr.Zero)
+            {
+                CloseHandle(processHandle);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resumes all threads of a suspended process.
+    /// </summary>
+    /// <param name="processId">The process ID to resume</param>
+    /// <returns>True if resumption succeeded, false otherwise</returns>
+    public static bool ResumeProcess(int processId)
+    {
+        if (processId <= 0)
+        {
+            return false;
+        }
+
+        IntPtr processHandle = IntPtr.Zero;
+        try
+        {
+            processHandle = OpenProcess(PROCESS_SUSPEND_RESUME, false, processId);
+            if (processHandle == IntPtr.Zero)
+            {
+                logger.Debug($"Failed to open process {processId} for resumption (access denied or process exited)");
+                return false;
+            }
+
+            int status = NtResumeProcess(processHandle);
+            if (status == STATUS_SUCCESS)
+            {
+                logger.Info($"Resumed process {processId}");
+                return true;
+            }
+            else
+            {
+                logger.Debug($"NtResumeProcess failed for process {processId} with status 0x{status:X8}");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Debug(ex, $"Exception while resuming process {processId}");
+            return false;
+        }
+        finally
+        {
+            if (processHandle != IntPtr.Zero)
+            {
+                CloseHandle(processHandle);
+            }
+        }
+    }
+}

--- a/src/OverlayPlugin/Interop/Win32Window.cs
+++ b/src/OverlayPlugin/Interop/Win32Window.cs
@@ -3,9 +3,15 @@ using System.Runtime.InteropServices;
 
 namespace PlayniteOverlay;
 
+/// <summary>
+/// Provides reliable window activation using AttachThreadInput pattern.
+/// This allows stealing focus from other applications without requiring
+/// hacky workarounds like simulating Alt key presses.
+/// </summary>
 internal static class Win32Window
 {
     private const int SW_RESTORE = 9;
+    private const int SW_SHOW = 5;
 
     [DllImport("user32.dll")]
     private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
@@ -13,6 +19,28 @@ internal static class Win32Window
     [DllImport("user32.dll")]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
 
+    [DllImport("user32.dll")]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out int processId);
+
+    [DllImport("user32.dll")]
+    private static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+
+    [DllImport("user32.dll")]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    [DllImport("kernel32.dll")]
+    private static extern uint GetCurrentThreadId();
+
+    /// <summary>
+    /// Restores (if minimized) and activates the specified window.
+    /// Uses AttachThreadInput pattern for reliable focus stealing.
+    /// </summary>
     public static void RestoreAndActivate(IntPtr hWnd)
     {
         if (hWnd == IntPtr.Zero)
@@ -22,15 +50,90 @@ internal static class Win32Window
 
         try
         {
-            // Always restore - handles both minimized and hidden (tray) windows
-            ShowWindow(hWnd, SW_RESTORE);
+            // Only restore if actually minimized - don't un-maximize maximized windows
+            if (IsIconic(hWnd))
+            {
+                ShowWindow(hWnd, SW_RESTORE);
+            }
+            else
+            {
+                // Ensure window is visible (handles tray windows)
+                ShowWindow(hWnd, SW_SHOW);
+            }
 
-            // Bring to foreground
-            SetForegroundWindow(hWnd);
+            // Use AttachThreadInput pattern for reliable focus stealing
+            ActivateWindowReliably(hWnd);
         }
         catch
         {
-            // ignore
+            // Fallback to basic activation
+            try
+            {
+                SetForegroundWindow(hWnd);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    /// <summary>
+    /// Activates a window reliably by attaching to the foreground thread.
+    /// Windows restricts SetForegroundWindow unless:
+    /// 1. The calling process is the foreground process, OR
+    /// 2. The calling thread is attached to the foreground thread
+    /// 
+    /// This method temporarily attaches our thread to the foreground window's
+    /// thread, which allows SetForegroundWindow to succeed.
+    /// </summary>
+    private static void ActivateWindowReliably(IntPtr targetWindow)
+    {
+        IntPtr foregroundWindow = GetForegroundWindow();
+        
+        // If target is already foreground, nothing to do
+        if (foregroundWindow == targetWindow)
+        {
+            return;
+        }
+
+        uint currentThreadId = GetCurrentThreadId();
+        uint foregroundThreadId = GetWindowThreadProcessId(foregroundWindow, out _);
+        uint targetThreadId = GetWindowThreadProcessId(targetWindow, out _);
+
+        bool attachedToForeground = false;
+        bool attachedToTarget = false;
+
+        try
+        {
+            // Attach our thread to the foreground window's thread
+            // This gives us permission to call SetForegroundWindow
+            if (foregroundThreadId != currentThreadId)
+            {
+                attachedToForeground = AttachThreadInput(currentThreadId, foregroundThreadId, true);
+            }
+
+            // Also attach to the target window's thread if different
+            if (targetThreadId != currentThreadId && targetThreadId != foregroundThreadId)
+            {
+                attachedToTarget = AttachThreadInput(currentThreadId, targetThreadId, true);
+            }
+
+            // Now we can reliably bring the window to foreground
+            BringWindowToTop(targetWindow);
+            SetForegroundWindow(targetWindow);
+        }
+        finally
+        {
+            // Always detach threads to avoid leaving them in a weird state
+            if (attachedToForeground)
+            {
+                AttachThreadInput(currentThreadId, foregroundThreadId, false);
+            }
+            if (attachedToTarget)
+            {
+                AttachThreadInput(currentThreadId, targetThreadId, false);
+            }
         }
     }
 }

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -201,13 +201,21 @@ public class OverlayPlugin : GenericPlugin
             .Select(g => OverlayItem.FromRecentGame(g, switcher))
             .ToList();
 
+        // Determine if we should suspend the active app's process
+        int processIdToSuspend = 0;
+        if (settings.Settings.SuspendGameWhileOverlayActive && switcher.ActiveApp != null)
+        {
+            processIdToSuspend = switcher.ActiveApp.ProcessId;
+        }
+
         overlay.Show(
             () => switcher.SwitchToPlaynite(),
             HandleExitGame,
             currentGameItem,
             runningApps,
             recentGames,
-            settings.Settings.UseControllerToOpen);
+            settings.Settings.UseControllerToOpen,
+            processIdToSuspend);
     }
 
     private void HandleExitGame()
@@ -299,6 +307,9 @@ public class OverlayPlugin : GenericPlugin
         // Clean up resources
         input.Stop();
         overlay.Hide();
+        
+        // Safety: ensure any suspended process is resumed on plugin unload
+        overlay.ResumeIfSuspended();
 
         base.Dispose();
     }

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -189,6 +189,8 @@ public class OverlayPlugin : GenericPlugin
         }
 
         // Get running apps (excluding active app)
+        // Set the active app's window handle so SwitchToApp knows what to minimize
+        runningAppsDetector.ActiveAppWindowHandle = switcher.ActiveApp?.WindowHandle ?? IntPtr.Zero;
         var runningApps = runningAppsDetector.GetRunningApps(
             excludeFromRunningApps,
             settings.Settings.ShowGenericApps,

--- a/src/OverlayPlugin/Services/GameSwitcher.cs
+++ b/src/OverlayPlugin/Services/GameSwitcher.cs
@@ -224,7 +224,8 @@ public sealed class GameSwitcher
 
     public void SwitchToPlaynite()
     {
-        System.Windows.Application.Current?.Dispatcher.Invoke(() =>
+        // Use BeginInvoke to avoid blocking if UI thread is busy
+        System.Windows.Application.Current?.Dispatcher.BeginInvoke(new Action(() =>
         {
             var mainWindow = System.Windows.Application.Current?.MainWindow;
             if (mainWindow == null)
@@ -241,7 +242,7 @@ public sealed class GameSwitcher
             // Show and activate (handles hidden/tray windows properly)
             mainWindow.Show();
             mainWindow.Activate();
-        });
+        }));
     }
 
     public void ExitActiveApp()

--- a/src/OverlayPlugin/Services/GameSwitcher.cs
+++ b/src/OverlayPlugin/Services/GameSwitcher.cs
@@ -224,6 +224,10 @@ public sealed class GameSwitcher
 
     public void SwitchToPlaynite()
     {
+        // Minimize the current foreground window first (handles fullscreen apps)
+        // Do this outside the dispatcher to ensure it happens immediately
+        IntPtr foreground = Win32Window.GetCurrentForegroundWindow();
+        
         // Use BeginInvoke to avoid blocking if UI thread is busy
         System.Windows.Application.Current?.Dispatcher.BeginInvoke(new Action(() =>
         {
@@ -231,6 +235,16 @@ public sealed class GameSwitcher
             if (mainWindow == null)
             {
                 return;
+            }
+
+            // Get Playnite's window handle
+            var helper = new System.Windows.Interop.WindowInteropHelper(mainWindow);
+            IntPtr playniteHandle = helper.Handle;
+
+            // Minimize foreground if it's not Playnite itself
+            if (foreground != IntPtr.Zero && foreground != playniteHandle)
+            {
+                Win32Window.MinimizeWindow(foreground);
             }
 
             // Restore if minimized

--- a/src/OverlayPlugin/Services/RunningAppsDetector.cs
+++ b/src/OverlayPlugin/Services/RunningAppsDetector.cs
@@ -195,7 +195,9 @@ public sealed class RunningAppsDetector
                 return;
             }
 
-            Win32Window.RestoreAndActivate(app.WindowHandle);
+            // Use SwitchToWindow which minimizes the foreground window first
+            // This ensures fullscreen apps don't visually cover the target
+            Win32Window.SwitchToWindow(app.WindowHandle);
             logger.Info($"Switched to app: {app.Title} (PID: {app.ProcessId})");
             
             // Notify subscribers that app was switched to

--- a/src/OverlayPlugin/Settings/OverlaySettings.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettings.cs
@@ -74,4 +74,15 @@ public class OverlaySettings : MVVM.ObservableObject
         get => borderlessDelayMs;
         set => SetProperty(ref borderlessDelayMs, value);
     }
+
+    private bool suspendGameWhileOverlayActive = false;
+    /// <summary>
+    /// When enabled, suspends the game process while the overlay is visible.
+    /// This prevents the game from receiving controller input while navigating the overlay.
+    /// </summary>
+    public bool SuspendGameWhileOverlayActive
+    {
+        get => suspendGameWhileOverlayActive;
+        set => SetProperty(ref suspendGameWhileOverlayActive, value);
+    }
 }

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
@@ -4,88 +4,104 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             d:DesignWidth="540" d:DesignHeight="320">
-    <StackPanel Margin="10" Orientation="Vertical" >
-        <TextBlock Text="Overlay Settings" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
+             d:DesignWidth="540" d:DesignHeight="480">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="10" Orientation="Vertical">
+            <TextBlock Text="Overlay Settings" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
 
-        <GroupBox Header="Keyboard Shortcut">
-            <StackPanel Margin="10">
-                <TextBlock Text="Set a custom global hotkey to toggle the overlay from anywhere." TextWrapping="Wrap"/>
-                <CheckBox Content="Enable custom global hotkey"
-                          Margin="0,8,0,0"
-                          IsChecked="{Binding Settings.EnableCustomHotkey}"/>
-                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                    <TextBlock Text="Custom hotkey:" VerticalAlignment="Center"/>
-                    <TextBox Width="200"
-                             Margin="8,0,0,0"
-                             Text="{Binding Settings.CustomHotkey}"
-                             IsReadOnly="True"
-                             PreviewKeyDown="Hotkey_PreviewKeyDown"
-                             ToolTip="Click here and press the desired key combo"/>
-                    <Button Margin="8,0,0,0" Content="Clear" Click="Hotkey_Clear_Click"/>
+            <GroupBox Header="Keyboard Shortcut">
+                <StackPanel Margin="10">
+                    <TextBlock Text="Set a custom global hotkey to toggle the overlay from anywhere." TextWrapping="Wrap"/>
+                    <CheckBox Content="Enable custom global hotkey"
+                              Margin="0,8,0,0"
+                              IsChecked="{Binding Settings.EnableCustomHotkey}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                        <TextBlock Text="Custom hotkey:" VerticalAlignment="Center"/>
+                        <TextBox Width="200"
+                                 Margin="8,0,0,0"
+                                 Text="{Binding Settings.CustomHotkey}"
+                                 IsReadOnly="True"
+                                 PreviewKeyDown="Hotkey_PreviewKeyDown"
+                                 ToolTip="Click here and press the desired key combo"/>
+                        <Button Margin="8,0,0,0" Content="Clear" Click="Hotkey_Clear_Click"/>
+                    </StackPanel>
                 </StackPanel>
-            </StackPanel>
-        </GroupBox>
+            </GroupBox>
 
-        <GroupBox Header="Controller">
-            <StackPanel Margin="10">
-                <CheckBox Content="Allow opening overlay with controller"
-                          IsChecked="{Binding Settings.UseControllerToOpen}"/>
-                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                    <TextBlock Text="Button combo:" VerticalAlignment="Center"/>
-                    <ComboBox Width="160" Margin="8,0,0,0"
-                              SelectedValuePath="Content"
-                              SelectedValue="{Binding Settings.ControllerCombo}">
-                        <ComboBoxItem Content="Guide" />
-                        <ComboBoxItem Content="Start+Back" />
-                        <ComboBoxItem Content="LB+RB" />
-                    </ComboBox>
+            <GroupBox Header="Controller">
+                <StackPanel Margin="10">
+                    <CheckBox Content="Allow opening overlay with controller"
+                              IsChecked="{Binding Settings.UseControllerToOpen}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                        <TextBlock Text="Button combo:" VerticalAlignment="Center"/>
+                        <ComboBox Width="160" Margin="8,0,0,0"
+                                  SelectedValuePath="Content"
+                                  SelectedValue="{Binding Settings.ControllerCombo}">
+                            <ComboBoxItem Content="Guide" />
+                            <ComboBoxItem Content="Start+Back" />
+                            <ComboBoxItem Content="LB+RB" />
+                        </ComboBox>
+                    </StackPanel>
+                    <CheckBox Content="Controller input always active (not just during gameplay)"
+                              Margin="0,8,0,0"
+                              IsChecked="{Binding Settings.ControllerAlwaysActive}"
+                              ToolTip="Warning: May conflict with system Xbox overlay when enabled"/>
+                    <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
+                               Foreground="Gray"
+                               Text="Note: Controller detection uses XInput and may not work with all devices yet."/>
                 </StackPanel>
-                <CheckBox Content="Controller input always active (not just during gameplay)"
-                          Margin="0,8,0,0"
-                          IsChecked="{Binding Settings.ControllerAlwaysActive}"
-                          ToolTip="Warning: May conflict with system Xbox overlay when enabled"/>
-                <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
-                           Foreground="Gray"
-                           Text="Note: Controller detection uses XInput and may not work with all devices yet."/>
-            </StackPanel>
-        </GroupBox>
+            </GroupBox>
 
-        <GroupBox Header="Running Apps Detection">
-            <StackPanel Margin="10">
-                <CheckBox Content="Show non-game applications (browsers, editors, etc.)"
-                          IsChecked="{Binding Settings.ShowGenericApps}"
-                          ToolTip="When enabled, shows all running apps with visible windows. When disabled, only shows games."/>
-                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                    <TextBlock Text="Maximum apps to display:" VerticalAlignment="Center"/>
-                    <TextBox Width="60" Margin="8,0,0,0"
-                             Text="{Binding Settings.MaxRunningApps, UpdateSourceTrigger=PropertyChanged}"
-                             ToolTip="Maximum number of running apps to show in the overlay (1-50)"/>
+            <GroupBox Header="Running Apps Detection">
+                <StackPanel Margin="10">
+                    <CheckBox Content="Show non-game applications (browsers, editors, etc.)"
+                              IsChecked="{Binding Settings.ShowGenericApps}"
+                              ToolTip="When enabled, shows all running apps with visible windows. When disabled, only shows games."/>
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <TextBlock Text="Maximum apps to display:" VerticalAlignment="Center"/>
+                        <TextBox Width="60" Margin="8,0,0,0"
+                                 Text="{Binding Settings.MaxRunningApps, UpdateSourceTrigger=PropertyChanged}"
+                                 ToolTip="Maximum number of running apps to show in the overlay (1-50)"/>
+                    </StackPanel>
+                    <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
+                               Foreground="Gray"
+                               Text="The overlay can detect and switch between multiple running games and applications."/>
                 </StackPanel>
-                <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
-                           Foreground="Gray"
-                           Text="The overlay can detect and switch between multiple running games and applications."/>
-            </StackPanel>
-        </GroupBox>
+            </GroupBox>
 
-        <GroupBox Header="Fullscreen Compatibility">
-            <StackPanel Margin="10">
-                <CheckBox Content="Force borderless windowed mode for games"
-                          IsChecked="{Binding Settings.ForceBorderlessMode}"
-                          ToolTip="Automatically converts windowed games to borderless fullscreen. This helps the overlay work on games that don't natively support it."/>
-                <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
-                           Foreground="Gray"
-                           Text="When enabled, games running in windowed mode will be converted to borderless fullscreen after launch. This allows the overlay to appear over the game."/>
-                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                    <TextBlock Text="Delay before applying (ms):" VerticalAlignment="Center"/>
-                    <TextBox Width="60" Margin="8,0,0,0"
-                             Text="{Binding Settings.BorderlessDelayMs, UpdateSourceTrigger=PropertyChanged}"
-                             ToolTip="Time to wait after game starts before applying borderless mode (1000-10000 ms)"/>
+            <GroupBox Header="Fullscreen Compatibility">
+                <StackPanel Margin="10">
+                    <CheckBox Content="Force borderless windowed mode for games"
+                              IsChecked="{Binding Settings.ForceBorderlessMode}"
+                              ToolTip="Automatically converts windowed games to borderless fullscreen. This helps the overlay work on games that don't natively support it."/>
+                    <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
+                               Foreground="Gray"
+                               Text="When enabled, games running in windowed mode will be converted to borderless fullscreen after launch. This allows the overlay to appear over the game."/>
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <TextBlock Text="Delay before applying (ms):" VerticalAlignment="Center"/>
+                        <TextBox Width="60" Margin="8,0,0,0"
+                                 Text="{Binding Settings.BorderlessDelayMs, UpdateSourceTrigger=PropertyChanged}"
+                                 ToolTip="Time to wait after game starts before applying borderless mode (1000-10000 ms)"/>
+                    </StackPanel>
+                    <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
+                               Foreground="Orange"
+                               Text="Note: This only works for games running in windowed mode. For games in true exclusive fullscreen, you'll need to change the game's display settings to Windowed or Borderless."/>
                 </StackPanel>
-                <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
-                           Foreground="Orange"
-                           Text="Note: This only works for games running in windowed mode. For games in true exclusive fullscreen, you'll need to change the game's display settings to Windowed or Borderless."/>
-            </StackPanel>
-        </GroupBox>
-    </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Game Suspension">
+                <StackPanel Margin="10">
+                    <CheckBox Content="Suspend game while overlay is active"
+                              IsChecked="{Binding Settings.SuspendGameWhileOverlayActive}"
+                              ToolTip="Pauses the game process while the overlay is visible. This prevents the game from receiving controller input."/>
+                    <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
+                               Foreground="Gray"
+                               Text="When enabled, the game process is temporarily suspended while the overlay is open. This prevents controller button presses from being sent to the game while navigating the overlay."/>
+                    <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
+                               Foreground="Orange"
+                               Text="Warning: Some games with anti-cheat software may not respond well to being suspended. If you experience issues, disable this option."/>
+                </StackPanel>
+            </GroupBox>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary

- Adds optional process suspension to prevent games from receiving controller input while the overlay is visible
- Uses Windows NT APIs (`NtSuspendProcess`/`NtResumeProcess`) for reliable process suspension

## Changes

- **New file**: `ProcessSuspender.cs` - Win32 interop for suspending/resuming processes
- **New setting**: "Suspend game while overlay is active" (default: OFF)
- **Settings UI**: Added ScrollViewer for better UX with growing settings list
- **Safety**: Process is automatically resumed on:
  - Overlay close
  - Plugin dispose/unload

## Why

When the overlay is visible, the game continues to poll XInput and receives controller button presses. This can cause unintended game actions while navigating the overlay. Suspending the process completely freezes it, preventing any input processing.

## Notes

- Default is OFF as some games with anti-cheat may not respond well to being suspended
- Includes warning in settings UI about potential anti-cheat issues
- Based on PR #17 (window switching reliability improvements)