### PR TITLE
feat(overlay): hide running apps from recent games list

### DIFF
--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -197,10 +197,10 @@ public class OverlayPlugin : GenericPlugin
             settings.Settings.MaxRunningApps);
 
         // Extract game IDs of running Playnite games to exclude from recent list
-        var runningGameIds = runningApps
-            .Where(a => a.Type == AppType.PlayniteGame && a.GameId.HasValue)
-            .Select(a => a.GameId.Value)
-            .ToHashSet();
+        var runningGameIds = new HashSet<Guid>(
+            runningApps
+                .Where(a => a.Type == AppType.PlayniteGame && a.GameId.HasValue)
+                .Select(a => a.GameId!.Value));
 
         // Build recent games list (excludes active app and running apps)
         var recentGames = switcher.GetRecentGames(5, runningGameIds)

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -196,8 +196,14 @@ public class OverlayPlugin : GenericPlugin
             settings.Settings.ShowGenericApps,
             settings.Settings.MaxRunningApps);
 
-        // Build recent games list (excludes active app if it's a game)
-        var recentGames = switcher.GetRecentGames(5)
+        // Extract game IDs of running Playnite games to exclude from recent list
+        var runningGameIds = runningApps
+            .Where(a => a.Type == AppType.PlayniteGame && a.GameId.HasValue)
+            .Select(a => a.GameId.Value)
+            .ToHashSet();
+
+        // Build recent games list (excludes active app and running apps)
+        var recentGames = switcher.GetRecentGames(5, runningGameIds)
             .Select(g => OverlayItem.FromRecentGame(g, switcher))
             .ToList();
 

--- a/src/OverlayPlugin/Services/GameSwitcher.cs
+++ b/src/OverlayPlugin/Services/GameSwitcher.cs
@@ -554,7 +554,7 @@ public sealed class GameSwitcher
 
     public IEnumerable<Playnite.SDK.Models.Game> GetRecentGames(int count, HashSet<Guid>? excludeGameIds = null)
     {
-        var games = api.Database.Games.AsQueryable();
+        var games = api.Database.Games;
         var query = games.Where(g => g.LastActivity != null);
 
         // Exclude active app if it's a Playnite game

--- a/tests/OverlayPlugin.Tests/GameSwitcherTests.cs
+++ b/tests/OverlayPlugin.Tests/GameSwitcherTests.cs
@@ -421,7 +421,7 @@ public class GameSwitcherTests
 
         mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
         mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
-        mockGames.Setup(g => g[gameId]).Returns(default(Game));
+        mockGames.Setup(g => g[gameId]).Returns((Game?)null);
 
         var switcher = new GameSwitcher(mockApi.Object);
 
@@ -445,7 +445,7 @@ public class GameSwitcherTests
         var game3 = new Game("Game 3") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-3) };
         
         var games = new List<Game> { game1, game2, game3 };
-        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        mockGames.As<IEnumerable<Game>>().Setup(g => g.GetEnumerator()).Returns(() => games.GetEnumerator());
         
         mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
         mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
@@ -476,7 +476,7 @@ public class GameSwitcherTests
         var game4 = new Game("Game 4") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-4) };
         
         var games = new List<Game> { game1, game2, game3, game4 };
-        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        mockGames.As<IEnumerable<Game>>().Setup(g => g.GetEnumerator()).Returns(() => games.GetEnumerator());
         
         mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
         mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
@@ -515,7 +515,7 @@ public class GameSwitcherTests
             });
         }
         
-        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        mockGames.As<IEnumerable<Game>>().Setup(g => g.GetEnumerator()).Returns(() => games.GetEnumerator());
         
         mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
         mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
@@ -549,7 +549,7 @@ public class GameSwitcherTests
         var game2 = new Game("Game 2") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-2) };
         
         var games = new List<Game> { game1, game2 };
-        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        mockGames.As<IEnumerable<Game>>().Setup(g => g.GetEnumerator()).Returns(() => games.GetEnumerator());
         
         mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
         mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);

--- a/tests/OverlayPlugin.Tests/GameSwitcherTests.cs
+++ b/tests/OverlayPlugin.Tests/GameSwitcherTests.cs
@@ -431,4 +431,137 @@ public class GameSwitcherTests
         // Assert
         Assert.Null(result);
     }
+
+    [Fact]
+    public void GetRecentGames_WithNoExclusions_ReturnsAllRecentGames()
+    {
+        // Arrange
+        var mockApi = new Mock<IPlayniteAPI>();
+        var mockDatabase = new Mock<IGameDatabaseAPI>();
+        var mockGames = new Mock<IItemCollection<Game>>();
+        
+        var game1 = new Game("Game 1") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-1) };
+        var game2 = new Game("Game 2") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-2) };
+        var game3 = new Game("Game 3") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-3) };
+        
+        var games = new List<Game> { game1, game2, game3 };
+        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        
+        mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
+        mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
+
+        var switcher = new GameSwitcher(mockApi.Object);
+
+        // Act
+        var result = switcher.GetRecentGames(5).ToList();
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Game 1", result[0].Name);
+        Assert.Equal("Game 2", result[1].Name);
+        Assert.Equal("Game 3", result[2].Name);
+    }
+
+    [Fact]
+    public void GetRecentGames_WithExclusionSet_ExcludesSpecifiedGames()
+    {
+        // Arrange
+        var mockApi = new Mock<IPlayniteAPI>();
+        var mockDatabase = new Mock<IGameDatabaseAPI>();
+        var mockGames = new Mock<IItemCollection<Game>>();
+        
+        var game1 = new Game("Game 1") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-1) };
+        var game2 = new Game("Game 2") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-2) };
+        var game3 = new Game("Game 3") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-3) };
+        var game4 = new Game("Game 4") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-4) };
+        
+        var games = new List<Game> { game1, game2, game3, game4 };
+        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        
+        mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
+        mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
+
+        var switcher = new GameSwitcher(mockApi.Object);
+        
+        // Exclude game2 and game3 (simulating they are running)
+        var excludeIds = new HashSet<Guid> { game2.Id, game3.Id };
+
+        // Act
+        var result = switcher.GetRecentGames(5, excludeIds).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Game 1", result[0].Name);
+        Assert.Equal("Game 4", result[1].Name);
+        Assert.DoesNotContain(result, g => g.Name == "Game 2");
+        Assert.DoesNotContain(result, g => g.Name == "Game 3");
+    }
+
+    [Fact]
+    public void GetRecentGames_WithExclusionSet_ReturnsRequestedCount()
+    {
+        // Arrange
+        var mockApi = new Mock<IPlayniteAPI>();
+        var mockDatabase = new Mock<IGameDatabaseAPI>();
+        var mockGames = new Mock<IItemCollection<Game>>();
+        
+        var games = new List<Game>();
+        for (int i = 1; i <= 10; i++)
+        {
+            games.Add(new Game($"Game {i}") 
+            { 
+                Id = Guid.NewGuid(), 
+                LastActivity = DateTime.Now.AddHours(-i) 
+            });
+        }
+        
+        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        
+        mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
+        mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
+
+        var switcher = new GameSwitcher(mockApi.Object);
+        
+        // Exclude games 2 and 3 (simulating they are running)
+        var excludeIds = new HashSet<Guid> { games[1].Id, games[2].Id };
+
+        // Act - request 5 games
+        var result = switcher.GetRecentGames(5, excludeIds).ToList();
+
+        // Assert - should still get 5 games (1, 4, 5, 6, 7)
+        Assert.Equal(5, result.Count);
+        Assert.Equal("Game 1", result[0].Name);
+        Assert.Equal("Game 4", result[1].Name);
+        Assert.Equal("Game 5", result[2].Name);
+        Assert.Equal("Game 6", result[3].Name);
+        Assert.Equal("Game 7", result[4].Name);
+    }
+
+    [Fact]
+    public void GetRecentGames_WithEmptyExclusionSet_ReturnsAllRecentGames()
+    {
+        // Arrange
+        var mockApi = new Mock<IPlayniteAPI>();
+        var mockDatabase = new Mock<IGameDatabaseAPI>();
+        var mockGames = new Mock<IItemCollection<Game>>();
+        
+        var game1 = new Game("Game 1") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-1) };
+        var game2 = new Game("Game 2") { Id = Guid.NewGuid(), LastActivity = DateTime.Now.AddHours(-2) };
+        
+        var games = new List<Game> { game1, game2 };
+        mockGames.Setup(g => g.AsQueryable()).Returns(games.AsQueryable());
+        
+        mockApi.Setup(a => a.Database).Returns(mockDatabase.Object);
+        mockDatabase.Setup(d => d.Games).Returns(mockGames.Object);
+
+        var switcher = new GameSwitcher(mockApi.Object);
+
+        // Act
+        var result = switcher.GetRecentGames(5, new HashSet<Guid>()).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Game 1", result[0].Name);
+        Assert.Equal("Game 2", result[1].Name);
+    }
 }


### PR DESCRIPTION
## Summary

- Prevents duplicate entries by excluding currently running Playnite games from the recent games list
- Running games already appear in the "Running Apps" section, so showing them again in "Recent Games" creates confusion and wastes space
- Maintains display of exactly 5 recent games after filtering out running apps

## Changes

- **GameSwitcher.cs**: Modified `GetRecentGames()` to accept an optional `HashSet<Guid>` exclusion parameter
- **OverlayPlugin.cs**: Updated `ToggleOverlay()` to extract running game IDs and pass them to `GetRecentGames()`
- **GameSwitcherTests.cs**: Added 4 comprehensive unit tests covering exclusion logic

## Implementation Details

The solution filters running games after detecting them:
1. Get running apps using `RunningAppsDetector`
2. Extract game IDs from running Playnite games into a `HashSet<Guid>`
3. Pass this set to `GetRecentGames()` which filters out matching IDs
4. Recent list backfills to maintain 5 games displayed

## Testing

Added unit tests for:
- Baseline behavior without exclusions
- Exclusion set properly filters specified games
- Always returns requested count (5 games) after exclusions
- Empty exclusion set behaves like no exclusions

Closes #[issue-number-if-applicable]