### PR TITLE
fix(settings): disable Show Generic Apps by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Show Generic Apps Default**: Changed default from enabled to disabled. New installations will only show Playnite-tracked games by default.
+
 ---
 
 ## [0.4.3] - 2025-12-22

--- a/src/OverlayPlugin/Settings/OverlaySettings.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettings.cs
@@ -39,7 +39,7 @@ public class OverlaySettings : MVVM.ObservableObject
         set => SetProperty(ref controllerAlwaysActive, value);
     }
 
-    private bool showGenericApps = true;
+    private bool showGenericApps = false;
     public bool ShowGenericApps
     {
         get => showGenericApps;

--- a/tests/OverlayPlugin.Tests/OverlaySettingsTests.cs
+++ b/tests/OverlayPlugin.Tests/OverlaySettingsTests.cs
@@ -18,7 +18,7 @@ public class OverlaySettingsTests
         Assert.True(settings.EnableCustomHotkey);
         Assert.Equal("Ctrl+Alt+O", settings.CustomHotkey);
         Assert.True(settings.ControllerAlwaysActive);
-        Assert.True(settings.ShowGenericApps);
+        Assert.False(settings.ShowGenericApps);
         Assert.Equal(4, settings.MaxRunningApps);
         Assert.False(settings.ForceBorderlessMode);
         Assert.Equal(3000, settings.BorderlessDelayMs);


### PR DESCRIPTION
## Summary
- Change default value of `ShowGenericApps` from `true` to `false`
- New installations will only show Playnite-tracked games in the overlay by default

Closes #22