### PR TITLE
feat(controller): add PC games only filter for controller input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Show Notifications Toggle**: New setting to enable/disable all overlay notifications (app switching, exit operations, errors).
+- **PC Games Only Mode**: Option to disable controller input for non-PC games
+  - Useful when emulators have their own overlays (RetroArch, etc.)
+  - Works with all controller settings (Controller Always Active enabled or disabled)
+  - Keyboard hotkey continues to work for all games regardless of this setting
+  - Games without platform metadata are treated as PC games (backward compatible)
+  - New setting: `PcGamesOnly` (default: disabled for backward compatibility)
+  - **Tip**: Set platform metadata for emulated games to prevent controller conflicts
 
 ### Changed
 - **Show Generic Apps Default**: Changed default from enabled to disabled. New installations will only show Playnite-tracked games by default.

--- a/src/OverlayPlugin/Input/InputListener.cs
+++ b/src/OverlayPlugin/Input/InputListener.cs
@@ -23,6 +23,7 @@ internal sealed class InputListener
     private string controllerCombo = "Guide";
     private string? customHotkeyGesture;
     private bool enableController = true;
+    private bool runtimeControllerEnabled = true; // Runtime override for game context (e.g., PC Games Only filter)
 
     // Overlay window reference for navigation (single polling loop)
     private OverlayWindow? overlayWindow;
@@ -145,6 +146,24 @@ internal sealed class InputListener
         pollTimer = null;
     }
 
+    /// <summary>
+    /// Enables controller input processing at runtime without affecting the polling timer.
+    /// Used for dynamic enable/disable based on game context (e.g., PC Games Only filter).
+    /// </summary>
+    public void EnableControllerInput()
+    {
+        runtimeControllerEnabled = true;
+    }
+
+    /// <summary>
+    /// Disables controller input processing at runtime without affecting the polling timer.
+    /// Used for dynamic enable/disable based on game context (e.g., PC Games Only filter).
+    /// </summary>
+    public void DisableControllerInput()
+    {
+        runtimeControllerEnabled = false;
+    }
+
     public void ApplySettings(OverlaySettings settings)
     {
         customHotkeyGesture = settings.EnableCustomHotkey ? settings.CustomHotkey : null;
@@ -161,9 +180,9 @@ internal sealed class InputListener
 
     private void PollControllers()
     {
-        if (!enableController)
+        if (!enableController || !runtimeControllerEnabled)
         {
-            // Controller polling is running but disabled in settings
+            // Controller polling is running but disabled in settings or runtime
             return;
         }
 

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -81,10 +81,22 @@ public class OverlayPlugin : GenericPlugin
         // Check if we should enable controller for this game
         bool shouldEnableController = !settings.Settings.PcGamesOnly || IsPcGame(args.Game);
 
-        // Start controller input if not already running (when not always-active)
-        if (!settings.Settings.ControllerAlwaysActive && shouldEnableController)
+        if (shouldEnableController)
         {
-            input.StartController();
+            // Enable controller input for this game
+            input.EnableControllerInput();
+            
+            // Start controller timer if not already running (when not always-active)
+            if (!settings.Settings.ControllerAlwaysActive)
+            {
+                input.StartController();
+            }
+        }
+        else
+        {
+            // Disable controller input for non-PC games when PcGamesOnly is enabled
+            logger.Info($"Disabling controller input for non-PC game: {args.Game.Name}");
+            input.DisableControllerInput();
         }
 
         // Apply borderless mode if enabled and we have a process ID
@@ -101,6 +113,9 @@ public class OverlayPlugin : GenericPlugin
 
         // Clear active app when game stops
         switcher.ClearActiveApp();
+        
+        // Re-enable controller input after game stops (in case it was disabled for non-PC game)
+        input.EnableControllerInput();
         
         // Stop controller input only if not configured to be always-active
         if (!settings.Settings.ControllerAlwaysActive)

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -287,8 +287,9 @@ public class OverlayPlugin : GenericPlugin
             if (BorderlessHelper.RestoreWindow(state))
             {
                 logger.Info($"Restored window state for {gameName}");
+            }
+            borderlessStates.Remove(gameId);
         }
-        borderlessStates.Remove(gameId);
     }
 
     /// <summary>

--- a/src/OverlayPlugin/Settings/OverlaySettings.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettings.cs
@@ -39,6 +39,17 @@ public class OverlaySettings : MVVM.ObservableObject
         set => SetProperty(ref controllerAlwaysActive, value);
     }
 
+    private bool pcGamesOnly = false;
+    /// <summary>
+    /// When enabled, controller input is only active for PC platform games.
+    /// Emulated games will not trigger controller overlay activation.
+    /// </summary>
+    public bool PcGamesOnly
+    {
+        get => pcGamesOnly;
+        set => SetProperty(ref pcGamesOnly, value);
+    }
+
     private bool showGenericApps = false;
     public bool ShowGenericApps
     {

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
@@ -46,6 +46,10 @@
                               Margin="0,8,0,0"
                               IsChecked="{Binding Settings.ControllerAlwaysActive}"
                               ToolTip="Warning: May conflict with system Xbox overlay when enabled"/>
+                    <CheckBox Content="Only enable controller for PC games"
+                              Margin="0,8,0,0"
+                              IsChecked="{Binding Settings.PcGamesOnly}"
+                              ToolTip="When enabled, controller input is disabled for emulated/console games. Useful when emulators have their own overlays."/>
                     <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
                                Foreground="Gray"
                                Text="Note: Controller detection uses XInput and may not work with all devices yet."/>


### PR DESCRIPTION
## Summary
- Add option to disable controller overlay activation for non-PC games
- Allows emulators (RetroArch, etc.) to use their own overlay systems without conflict
- Keyboard hotkey continues to work for all games regardless of this setting

## Changes
- `OverlaySettings.cs`: Add `PcGamesOnly` setting (default: `false`)
- `OverlaySettingsView.xaml`: Add checkbox in Controller settings section
- `OverlayPlugin.cs`: Add `IsPcGame()` helper, skip controller in `OnGameStarted` for non-PC games

## How It Works
1. When `PcGamesOnly` is enabled and a game starts:
   - Check if game has any PC platform ("PC", "PC (Windows)", or contains "Windows")
   - If no PC platform found, skip controller activation
   - If no platform metadata exists, assume PC (backward compatible)
2. Keyboard hotkey always works regardless of this setting

## Testing
- [x] Build passes on Windows
- [x] PC game starts -> controller enabled
- [x] Emulated game starts -> controller disabled (when setting enabled)
- [x] Keyboard hotkey works for both
- [x] Setting disabled by default (backward compatible)

Closes #27