### PR TITLE
feat(audio): add audio device switcher to overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Audio Device Switcher**: Switch default Windows audio output device directly from the overlay
+  - Shows dropdown with all active audio output devices
+  - Displays current default device with indicator
+  - Auto-hides when no audio devices detected or NAudio fails to initialize
+  - Uses NAudio 2.2.1 for device enumeration
+  - Switches device for all roles (Multimedia, Console, Communications)
 - **Show Notifications Toggle**: New setting to enable/disable all overlay notifications (app switching, exit operations, errors).
 - **PC Games Only Mode**: Option to disable controller input for non-PC games
   - Useful when emulators have their own overlays (RetroArch, etc.)

--- a/src/OverlayPlugin/Models/AudioDevice.cs
+++ b/src/OverlayPlugin/Models/AudioDevice.cs
@@ -1,0 +1,11 @@
+namespace PlayniteOverlay.Models;
+
+/// <summary>
+/// Represents an audio output device.
+/// </summary>
+public sealed class AudioDevice
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public bool IsDefault { get; set; }
+}

--- a/src/OverlayPlugin/Models/AudioDevice.cs
+++ b/src/OverlayPlugin/Models/AudioDevice.cs
@@ -1,11 +1,34 @@
+using System.ComponentModel;
+
 namespace PlayniteOverlay.Models;
 
 /// <summary>
 /// Represents an audio output device.
 /// </summary>
-public sealed class AudioDevice
+public sealed class AudioDevice : INotifyPropertyChanged
 {
+    private bool isDefault;
+    
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-    public bool IsDefault { get; set; }
+    
+    public bool IsDefault
+    {
+        get => isDefault;
+        set
+        {
+            if (isDefault != value)
+            {
+                isDefault = value;
+                OnPropertyChanged(nameof(IsDefault));
+            }
+        }
+    }
+    
+    public event PropertyChangedEventHandler? PropertyChanged;
+    
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
 }

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -287,11 +287,12 @@ public class OverlayPlugin : GenericPlugin
         }
     }
 
-    private void SwitchAudioDevice(string deviceId)
+    private void SwitchAudioDevice(string deviceId, Action<bool> onComplete)
     {
         if (audioDeviceService == null)
         {
             logger.Warn("Cannot switch audio device: AudioDeviceService not initialized");
+            onComplete(false);
             return;
         }
 
@@ -301,15 +302,18 @@ public class OverlayPlugin : GenericPlugin
             if (success)
             {
                 logger.Info($"Successfully switched audio device to {deviceId}");
+                onComplete(true);
             }
             else
             {
                 logger.Warn($"Failed to switch audio device to {deviceId}");
+                onComplete(false);
             }
         }
         catch (Exception ex)
         {
             logger.Error(ex, $"Error switching audio device to {deviceId}");
+            onComplete(false);
         }
     }
 

--- a/src/OverlayPlugin/OverlayPlugin.csproj
+++ b/src/OverlayPlugin/OverlayPlugin.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="PlayniteSDK" Version="6.12.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationFramework" />

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -382,6 +382,41 @@
                         </ListBox>
                         </StackPanel>
                     </Border>
+                    
+                    <!-- Audio Device Section (auto-hidden when no devices) -->
+                    <Border x:Name="AudioSection" Background="#252525" CornerRadius="8" 
+                            Padding="16" Margin="20,0,0,0" Visibility="Collapsed"
+                            BorderThickness="2" BorderBrush="Transparent" Focusable="False">
+                        <StackPanel>
+                            <TextBlock Text="AUDIO OUTPUT" FontSize="10" FontWeight="Bold" 
+                                       Foreground="#888888" Margin="0,0,0,10"/>
+                            
+                            <ComboBox x:Name="AudioDeviceCombo" 
+                                      Background="#2A2A2A" 
+                                      Foreground="#EEEEEE"
+                                      BorderBrush="#3A3A3A"
+                                      FontSize="13"
+                                      Padding="10,8"
+                                      SelectionChanged="OnAudioDeviceChanged">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="🔊 " FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                            <TextBlock Text="{Binding Name}" FontSize="13" VerticalAlignment="Center"/>
+                                            <TextBlock x:Name="DefaultIndicator" Text=" (Default)" 
+                                                       FontSize="11" Foreground="#4A90E2" 
+                                                       VerticalAlignment="Center" Visibility="Collapsed"/>
+                                        </StackPanel>
+                                        <DataTemplate.Triggers>
+                                            <DataTrigger Binding="{Binding IsDefault}" Value="True">
+                                                <Setter TargetName="DefaultIndicator" Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </DataTemplate.Triggers>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                    </Border>
                 </StackPanel>
             </ScrollViewer>
         </Border>

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -32,6 +32,7 @@
                                 <ColumnDefinition Width="140"/>
                                 <ColumnDefinition Width="20"/>
                                 <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             
                             <!-- Cover Image -->
@@ -127,6 +128,42 @@
                                         </Button.Style>
                                     </Button>
                                 </StackPanel>
+                            </StackPanel>
+                            
+                            <!-- Audio Device Selector (Top-Right Corner) -->
+                            <StackPanel Grid.Column="3" Grid.Row="0" 
+                                        VerticalAlignment="Top" HorizontalAlignment="Right" 
+                                        Margin="12,0,0,0">
+                                <ComboBox x:Name="AudioDeviceCombo"
+                                          Background="#2A2A2A"
+                                          Foreground="#EEEEEE"
+                                          BorderBrush="#3A3A3A"
+                                          FontSize="11"
+                                          Padding="8,6"
+                                          MinWidth="160"
+                                          MaxWidth="200"
+                                          Visibility="Collapsed"
+                                          Focusable="True"
+                                          SelectionChanged="OnAudioDeviceChanged">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="🔊 " FontSize="12" 
+                                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                <TextBlock Text="{Binding Name}" FontSize="11" 
+                                                           VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock x:Name="DefaultIndicator" Text=" •" 
+                                                           FontSize="11" Foreground="#4A90E2" 
+                                                           VerticalAlignment="Center" Visibility="Collapsed"/>
+                                            </StackPanel>
+                                            <DataTemplate.Triggers>
+                                                <DataTrigger Binding="{Binding IsDefault}" Value="True">
+                                                    <Setter TargetName="DefaultIndicator" Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </DataTemplate.Triggers>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
                             </StackPanel>
                         </Grid>
                     </Border>
@@ -382,41 +419,7 @@
                         </ListBox>
                         </StackPanel>
                     </Border>
-                    
-                    <!-- Audio Device Section (auto-hidden when no devices) -->
-                    <Border x:Name="AudioSection" Background="#252525" CornerRadius="8" 
-                            Padding="16" Margin="0,20,0,0" Visibility="Collapsed"
-                            BorderThickness="2" BorderBrush="Transparent" Focusable="False">
-                        <StackPanel>
-                            <TextBlock Text="AUDIO OUTPUT" FontSize="10" FontWeight="Bold" 
-                                       Foreground="#888888" Margin="0,0,0,10"/>
-                            
-                            <ComboBox x:Name="AudioDeviceCombo" 
-                                      Background="#2A2A2A" 
-                                      Foreground="#EEEEEE"
-                                      BorderBrush="#3A3A3A"
-                                      FontSize="13"
-                                      Padding="10,8"
-                                      SelectionChanged="OnAudioDeviceChanged">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="🔊 " FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                            <TextBlock Text="{Binding Name}" FontSize="13" VerticalAlignment="Center"/>
-                                            <TextBlock x:Name="DefaultIndicator" Text=" (Default)" 
-                                                       FontSize="11" Foreground="#4A90E2" 
-                                                       VerticalAlignment="Center" Visibility="Collapsed"/>
-                                        </StackPanel>
-                                        <DataTemplate.Triggers>
-                                            <DataTrigger Binding="{Binding IsDefault}" Value="True">
-                                                <Setter TargetName="DefaultIndicator" Property="Visibility" Value="Visible"/>
-                                            </DataTrigger>
-                                        </DataTemplate.Triggers>
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
-                        </StackPanel>
-                    </Border>
+
                 </StackPanel>
             </ScrollViewer>
         </Border>

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -148,11 +148,46 @@
                                           SelectionChanged="OnAudioDeviceChanged">
                                     <ComboBox.Style>
                                         <Style TargetType="ComboBox">
-                                            <Style.Triggers>
-                                                <Trigger Property="IsKeyboardFocused" Value="True">
-                                                    <Setter Property="BorderBrush" Value="#FFFFFF"/>
-                                                </Trigger>
-                                            </Style.Triggers>
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ComboBox">
+                                                        <Grid>
+                                                            <ToggleButton x:Name="ToggleButton"
+                                                                          Background="{TemplateBinding Background}"
+                                                                          BorderBrush="{TemplateBinding BorderBrush}"
+                                                                          BorderThickness="{TemplateBinding BorderThickness}"
+                                                                          Focusable="False"
+                                                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                          ClickMode="Press"/>
+                                                            <ContentPresenter Content="{TemplateBinding SelectionBoxItem}"
+                                                                            ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                                            Margin="8,6"
+                                                                            VerticalAlignment="Center"
+                                                                            HorizontalAlignment="Left"
+                                                                            IsHitTestVisible="False"/>
+                                                            <Popup IsOpen="{TemplateBinding IsDropDownOpen}"
+                                                                   Placement="Bottom"
+                                                                   AllowsTransparency="True"
+                                                                   Focusable="False">
+                                                                <Border Background="#252525"
+                                                                        BorderBrush="#3A3A3A"
+                                                                        BorderThickness="1"
+                                                                        MinWidth="{TemplateBinding ActualWidth}"
+                                                                        MaxHeight="200">
+                                                                    <ScrollViewer>
+                                                                        <StackPanel IsItemsHost="True"/>
+                                                                    </ScrollViewer>
+                                                                </Border>
+                                                            </Popup>
+                                                        </Grid>
+                                                        <ControlTemplate.Triggers>
+                                                            <Trigger Property="IsKeyboardFocused" Value="True">
+                                                                <Setter TargetName="ToggleButton" Property="BorderBrush" Value="#FFFFFF"/>
+                                                            </Trigger>
+                                                        </ControlTemplate.Triggers>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
                                         </Style>
                                     </ComboBox.Style>
                                     <ComboBox.ItemContainerStyle>

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -165,6 +165,12 @@
                                                                             VerticalAlignment="Center"
                                                                             HorizontalAlignment="Left"
                                                                             IsHitTestVisible="False"/>
+                                                            <Path Data="M 0 0 L 4 4 L 8 0 Z"
+                                                                  Fill="#EEEEEE"
+                                                                  HorizontalAlignment="Right"
+                                                                  VerticalAlignment="Center"
+                                                                  Margin="0,0,10,0"
+                                                                  IsHitTestVisible="False"/>
                                                             <Popup IsOpen="{TemplateBinding IsDropDownOpen}"
                                                                    Placement="Bottom"
                                                                    AllowsTransparency="True"

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -161,7 +161,7 @@
                                                                           ClickMode="Press"/>
                                                             <ContentPresenter Content="{TemplateBinding SelectionBoxItem}"
                                                                             ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                                                            Margin="8,6"
+                                                                            Margin="8,6,28,6"
                                                                             VerticalAlignment="Center"
                                                                             HorizontalAlignment="Left"
                                                                             IsHitTestVisible="False"/>

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -385,7 +385,7 @@
                     
                     <!-- Audio Device Section (auto-hidden when no devices) -->
                     <Border x:Name="AudioSection" Background="#252525" CornerRadius="8" 
-                            Padding="16" Margin="20,0,0,0" Visibility="Collapsed"
+                            Padding="16" Margin="0,20,0,0" Visibility="Collapsed"
                             BorderThickness="2" BorderBrush="Transparent" Focusable="False">
                         <StackPanel>
                             <TextBlock Text="AUDIO OUTPUT" FontSize="10" FontWeight="Bold" 

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -32,7 +32,7 @@
                                 <ColumnDefinition Width="140"/>
                                 <ColumnDefinition Width="20"/>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="220"/>
                             </Grid.ColumnDefinitions>
                             
                             <!-- Cover Image -->

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -155,6 +155,32 @@
                                             </Style.Triggers>
                                         </Style>
                                     </ComboBox.Style>
+                                    <ComboBox.ItemContainerStyle>
+                                        <Style TargetType="ComboBoxItem">
+                                            <Setter Property="Background" Value="#2A2A2A"/>
+                                            <Setter Property="Foreground" Value="#EEEEEE"/>
+                                            <Setter Property="Padding" Value="8,6"/>
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ComboBoxItem">
+                                                        <Border x:Name="ItemBorder"
+                                                                Background="{TemplateBinding Background}"
+                                                                Padding="{TemplateBinding Padding}">
+                                                            <ContentPresenter/>
+                                                        </Border>
+                                                        <ControlTemplate.Triggers>
+                                                            <Trigger Property="IsHighlighted" Value="True">
+                                                                <Setter TargetName="ItemBorder" Property="Background" Value="#3A3A3A"/>
+                                                            </Trigger>
+                                                            <Trigger Property="IsSelected" Value="True">
+                                                                <Setter TargetName="ItemBorder" Property="Background" Value="#4A4A4A"/>
+                                                            </Trigger>
+                                                        </ControlTemplate.Triggers>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </ComboBox.ItemContainerStyle>
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -138,6 +138,7 @@
                                           Background="#2A2A2A"
                                           Foreground="#EEEEEE"
                                           BorderBrush="#3A3A3A"
+                                          BorderThickness="2"
                                           FontSize="11"
                                           Padding="8,6"
                                           MinWidth="160"
@@ -145,6 +146,15 @@
                                           Visibility="Collapsed"
                                           Focusable="True"
                                           SelectionChanged="OnAudioDeviceChanged">
+                                    <ComboBox.Style>
+                                        <Style TargetType="ComboBox">
+                                            <Style.Triggers>
+                                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                                    <Setter Property="BorderBrush" Value="#FFFFFF"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ComboBox.Style>
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -680,6 +680,10 @@ public partial class OverlayWindow : Window
                 case NavigationTarget.ExitButton:
                     ExitBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                     break;
+                case NavigationTarget.AudioDeviceCombo:
+                    // Open the ComboBox dropdown when Enter is pressed
+                    AudioDeviceCombo.IsDropDownOpen = true;
+                    break;
                 case NavigationTarget.RunningAppItem:
                     if (runningAppSelectedIndex >= 0 && runningAppSelectedIndex < runningApps.Count)
                     {
@@ -702,6 +706,13 @@ public partial class OverlayWindow : Window
 
     private void PerformCancel()
     {
+        // If the audio ComboBox dropdown is open, close it first
+        if (AudioDeviceCombo.IsDropDownOpen)
+        {
+            AudioDeviceCombo.IsDropDownOpen = false;
+            return;
+        }
+        
         if (isInsideSection)
         {
             // Exit to section level

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -193,6 +193,14 @@ public partial class OverlayWindow : Window
 
     private void OnPreviewKeyDown(object sender, KeyEventArgs e)
     {
+        // If audio ComboBox dropdown is open, let it handle its own navigation
+        if (AudioDeviceCombo.IsDropDownOpen && 
+            (e.Key == Key.Up || e.Key == Key.Down || e.Key == Key.Enter))
+        {
+            // Don't mark as handled - let the ComboBox receive these keys
+            return;
+        }
+        
         switch (e.Key)
         {
             case Key.Escape:

--- a/src/OverlayPlugin/Services/AudioDeviceService.cs
+++ b/src/OverlayPlugin/Services/AudioDeviceService.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using NAudio.CoreAudioApi;
+using Playnite.SDK;
+using PlayniteOverlay.Models;
+
+namespace PlayniteOverlay.Services;
+
+/// <summary>
+/// Service for managing Windows audio output devices.
+/// Uses NAudio for device enumeration and COM interop for switching default device.
+/// </summary>
+public sealed class AudioDeviceService : IDisposable
+{
+    private readonly ILogger logger;
+    private readonly MMDeviceEnumerator? enumerator;
+    private bool disposed;
+
+    public AudioDeviceService()
+    {
+        logger = LogManager.GetLogger();
+        try
+        {
+            enumerator = new MMDeviceEnumerator();
+            logger.Debug("AudioDeviceService initialized successfully");
+        }
+        catch (Exception ex)
+        {
+            logger.Warn(ex, "Failed to initialize MMDeviceEnumerator");
+            enumerator = null;
+        }
+    }
+
+    /// <summary>
+    /// Gets a list of all active audio output devices.
+    /// Returns null if enumeration fails or no devices found.
+    /// </summary>
+    public List<AudioDevice>? GetOutputDevices()
+    {
+        if (enumerator == null)
+        {
+            logger.Debug("Enumerator not available, cannot get output devices");
+            return null;
+        }
+
+        try
+        {
+            var deviceCollection = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+            if (deviceCollection == null || deviceCollection.Count == 0)
+            {
+                logger.Debug("No active audio output devices found");
+                return null;
+            }
+
+            var defaultDevice = GetDefaultDevice();
+            var defaultId = defaultDevice?.Id;
+
+            var devices = new List<AudioDevice>();
+            foreach (var device in deviceCollection)
+            {
+                try
+                {
+                    devices.Add(new AudioDevice
+                    {
+                        Id = device.ID,
+                        Name = device.FriendlyName,
+                        IsDefault = device.ID == defaultId
+                    });
+                }
+                catch (Exception ex)
+                {
+                    logger.Debug(ex, $"Error reading device info for {device.ID}");
+                }
+            }
+
+            logger.Debug($"Found {devices.Count} active audio output devices");
+            return devices.Count > 0 ? devices : null;
+        }
+        catch (Exception ex)
+        {
+            logger.Debug(ex, "Error enumerating audio output devices");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current default audio output device.
+    /// Returns null if no default device is set or enumeration fails.
+    /// </summary>
+    public AudioDevice? GetDefaultDevice()
+    {
+        if (enumerator == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var defaultDevice = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+            if (defaultDevice == null)
+            {
+                return null;
+            }
+
+            return new AudioDevice
+            {
+                Id = defaultDevice.ID,
+                Name = defaultDevice.FriendlyName,
+                IsDefault = true
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.Debug(ex, "Error getting default audio device");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Sets the specified device as the default audio output device for all roles.
+    /// Returns true if successful, false otherwise.
+    /// </summary>
+    public bool SetDefaultDevice(string deviceId)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+        {
+            logger.Warn("Cannot set default device: deviceId is null or empty");
+            return false;
+        }
+
+        try
+        {
+            var policyConfig = new PolicyConfigClient();
+            var config = (IPolicyConfig)policyConfig;
+
+            // Set as default for all three roles to ensure consistent behavior
+            var result1 = config.SetDefaultEndpoint(deviceId, Role.Multimedia);
+            var result2 = config.SetDefaultEndpoint(deviceId, Role.Console);
+            var result3 = config.SetDefaultEndpoint(deviceId, Role.Communications);
+
+            if (result1 == 0 && result2 == 0 && result3 == 0)
+            {
+                logger.Info($"Successfully set default audio device to {deviceId}");
+                return true;
+            }
+            else
+            {
+                logger.Warn($"Failed to set default audio device (results: {result1}, {result2}, {result3})");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, $"Error setting default audio device to {deviceId}");
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            enumerator?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.Debug(ex, "Error disposing AudioDeviceService");
+        }
+
+        disposed = true;
+    }
+}
+
+#region COM Interop
+
+/// <summary>
+/// COM class for PolicyConfig interface.
+/// GUID: 870af99c-171d-4f9e-af0d-e63df40c2bc9
+/// </summary>
+[ComImport]
+[Guid("870af99c-171d-4f9e-af0d-e63df40c2bc9")]
+internal class PolicyConfigClient
+{
+}
+
+/// <summary>
+/// IPolicyConfig interface for setting default audio endpoints.
+/// GUID: f8679f50-850a-41cf-9c72-430f290290c8
+/// </summary>
+[ComImport]
+[Guid("f8679f50-850a-41cf-9c72-430f290290c8")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IPolicyConfig
+{
+    [PreserveSig]
+    int GetMixFormat(string pszDeviceName, IntPtr ppFormat);
+
+    [PreserveSig]
+    int GetDeviceFormat(string pszDeviceName, bool bDefault, IntPtr ppFormat);
+
+    [PreserveSig]
+    int ResetDeviceFormat(string pszDeviceName);
+
+    [PreserveSig]
+    int SetDeviceFormat(string pszDeviceName, IntPtr pEndpointFormat, IntPtr mixFormat);
+
+    [PreserveSig]
+    int GetProcessingPeriod(string pszDeviceName, bool bDefault, IntPtr pmftDefaultPeriod, IntPtr pmftMinimumPeriod);
+
+    [PreserveSig]
+    int SetProcessingPeriod(string pszDeviceName, IntPtr pmftPeriod);
+
+    [PreserveSig]
+    int GetShareMode(string pszDeviceName, IntPtr pMode);
+
+    [PreserveSig]
+    int SetShareMode(string pszDeviceName, IntPtr mode);
+
+    [PreserveSig]
+    int GetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+
+    [PreserveSig]
+    int SetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+
+    [PreserveSig]
+    int SetDefaultEndpoint(string pszDeviceName, Role role);
+
+    [PreserveSig]
+    int SetEndpointVisibility(string pszDeviceName, bool bVisible);
+}
+
+#endregion

--- a/src/OverlayPlugin/Services/OverlayService.cs
+++ b/src/OverlayPlugin/Services/OverlayService.cs
@@ -25,7 +25,7 @@ internal sealed class OverlayService
         get { lock (windowLock) return window != null; }
     }
 
-    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames)
+    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string>? onAudioDeviceChanged = null)
     {
         lock (windowLock)
         {
@@ -36,7 +36,7 @@ internal sealed class OverlayService
 
             Application.Current?.Dispatcher.Invoke(() =>
             {
-                window = new OverlayWindow(onSwitch, onExit, currentGame, runningApps, recentGames);
+                window = new OverlayWindow(onSwitch, onExit, currentGame, runningApps, recentGames, audioDevices, onAudioDeviceChanged);
 
                 window.Loaded += (_, _) =>
                 {

--- a/src/OverlayPlugin/Services/OverlayService.cs
+++ b/src/OverlayPlugin/Services/OverlayService.cs
@@ -25,7 +25,7 @@ internal sealed class OverlayService
         get { lock (windowLock) return window != null; }
     }
 
-    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string>? onAudioDeviceChanged = null)
+    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string, Action<bool>>? onAudioDeviceChanged = null)
     {
         lock (windowLock)
         {


### PR DESCRIPTION
## Summary
Implements audio device switching functionality in the overlay (#28).

## Changes
- **AudioDevice Model** (`Models/AudioDevice.cs`): Simple model with Id, Name, IsDefault properties
- **AudioDeviceService** (`Services/AudioDeviceService.cs`): Service for enumerating and switching audio devices
  - Uses NAudio 2.2.1 for device enumeration via `MMDeviceEnumerator`
  - COM interop with `PolicyConfigClient` for setting default device
  - Sets device for all 3 roles (Multimedia, Console, Communications)
  - Graceful error handling with silent failures
- **OverlayWindow.xaml**: Added audio section at bottom of overlay
  - ComboBox dropdown with speaker emoji and "(Default)" indicator
  - Auto-hides when no devices detected
  - Matches existing UI style (dark theme, consistent spacing)
- **Integration**: Wired up service initialization, device fetching, and switching logic

## Technical Details
- **NAudio 2.2.1**: Compatible with .NET Framework 4.7.2
- **COM Interop**: `PolicyConfigClient` (GUID: 870af99c-171d-4f9e-af0d-e63df40c2bc9)
- **Auto-hide behavior**: Section only visible when devices successfully enumerated
- **Error handling**: All exceptions logged, service set to null on init failure
- **Resource cleanup**: Proper disposal of AudioDeviceService and MMDeviceEnumerator

## Closes
Closes #28