### PR TITLE
feat(ui): add time and playtime display to overlay header

### DIFF
--- a/src/OverlayPlugin/Models/OverlayItem.cs
+++ b/src/OverlayPlugin/Models/OverlayItem.cs
@@ -10,6 +10,7 @@ public sealed class OverlayItem
     public string? SecondaryText { get; set; }    // "2h ago" or "Playing for 45m"
     public bool IsCurrentGame { get; set; }       // For styling/behavior
     public Action? OnSelect { get; set; }
+    public DateTime? ActivatedTime { get; set; }
 
     // Achievement data (only populated for current game when SuccessStory is available)
     public GameAchievementSummary? Achievements { get; set; }
@@ -50,7 +51,8 @@ public sealed class OverlayItem
                     ImagePath = imagePath,
                     SecondaryText = $"Playing for {sessionDuration}",
                     IsCurrentGame = true,
-                    OnSelect = null  // Can't switch to self
+                    OnSelect = null,  // Can't switch to self
+                    ActivatedTime = app.ActivatedTime
                 };
             }
         }
@@ -63,7 +65,8 @@ public sealed class OverlayItem
             ImagePath = app.ImagePath,
             SecondaryText = $"Active for {sessionDuration}",
             IsCurrentGame = true,
-            OnSelect = null  // Can't switch to self
+            OnSelect = null,  // Can't switch to self
+            ActivatedTime = app.ActivatedTime
         };
     }
 

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -280,7 +280,8 @@ public class OverlayPlugin : GenericPlugin
             audioDevices,
             SwitchAudioDevice,
             gameVolumeService,
-            switcher.ActiveApp?.ProcessId);
+            switcher.ActiveApp?.ProcessId,
+            switcher);
     }
 
     private void HandleExitGame()

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -20,8 +20,16 @@
                           Focusable="False">
                 <StackPanel>
                     <!-- Header -->
-                    <TextBlock Text="Playnite Overlay" FontSize="24" FontWeight="SemiBold" 
-                               Foreground="#EEEEEE" Margin="0,0,0,20"/>
+                    <Grid Margin="0,0,0,20">
+                        <TextBlock Text="Playnite Overlay" FontSize="24" FontWeight="SemiBold" 
+                                   Foreground="#EEEEEE" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
+                        <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom" Orientation="Vertical">
+                            <TextBlock x:Name="TimeDisplay" Text="" FontSize="14" FontWeight="Medium"
+                                       Foreground="#AAAAAA" TextAlignment="Right"/>
+                            <TextBlock x:Name="PlaytimeDisplay" Text="" FontSize="11"
+                                       Foreground="#888888" TextAlignment="Right" Visibility="Collapsed"/>
+                        </StackPanel>
+                    </Grid>
                     
                     <!-- Current Game Section (collapsed when no game running) -->
                     <Border x:Name="CurrentGameSection" Background="#252525" CornerRadius="8" 

--- a/src/OverlayPlugin/Services/OverlayService.cs
+++ b/src/OverlayPlugin/Services/OverlayService.cs
@@ -25,7 +25,7 @@ internal sealed class OverlayService
         get { lock (windowLock) return window != null; }
     }
 
-    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string, Action<bool>>? onAudioDeviceChanged = null, GameVolumeService? gameVolumeService = null, int? currentGameProcessId = null)
+    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string, Action<bool>>? onAudioDeviceChanged = null, GameVolumeService? gameVolumeService = null, int? currentGameProcessId = null, GameSwitcher? gameSwitcher = null)
     {
         lock (windowLock)
         {
@@ -36,7 +36,7 @@ internal sealed class OverlayService
 
             Application.Current?.Dispatcher.Invoke(() =>
             {
-                window = new OverlayWindow(onSwitch, onExit, currentGame, runningApps, recentGames, audioDevices, onAudioDeviceChanged, gameVolumeService, currentGameProcessId);
+                window = new OverlayWindow(onSwitch, onExit, currentGame, runningApps, recentGames, audioDevices, onAudioDeviceChanged, gameVolumeService, currentGameProcessId, gameSwitcher);
 
                 window.Loaded += (_, _) =>
                 {


### PR DESCRIPTION
## Summary

- Adds current time display (12-hour format) to the overlay header top-right corner
- Adds playtime duration display ("Playing for Xh Xm") below the time when a game is active
- Updates both displays every second via DispatcherTimer

## Changes

- **OverlayItem.cs**: Added `ActivatedTime` property for live playtime tracking
- **OverlayService.cs**: Pass `GameSwitcher` to `OverlayWindow` for session duration calculation
- **OverlayPlugin.cs**: Pass `switcher` to overlay service
- **OverlayWindow.xaml**: Changed header to Grid layout with TimeDisplay and PlaytimeDisplay
- **OverlayWindow.xaml.cs**: Added DispatcherTimer and UpdateTimeDisplay logic

## Testing

- [x] Build passes: `dotnet build`
- [ ] Manual testing on Windows with Playnite (requires Windows)

Addresses #34 (comment about displaying time)