### PR TITLE
feat(shortcuts): add command-line and SendInput actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ Access settings through: **Playnite Menu** → **Add-ons** → **Extension setti
 - **Show Generic Apps**: Include non-game applications in RUNNING APPS section
 - **Max Running Apps**: Limit number of apps displayed (1-50, default: 10)
 
+### Shortcuts
+Configure custom shortcut buttons in the overlay that run shell commands:
+- **Add shortcuts** in settings (up to 10)
+- **Shortcuts appear** as buttons in a SHORTCUTS section in the overlay
+- **Click to execute** the configured command
+
+#### Example Configurations
+
+**ShareX Screenshot:**
+- Label: `Screenshot`
+- Command: `C:\Program Files\ShareX\ShareX.exe`
+- Arguments: `-screenshot`
+
+**OBS Recording:**
+- Label: `Record`
+- Command: `C:\Program Files\obs-studio\bin\64bit\obs64.exe`
+- Arguments: `--startrecording`
+
+**Simple Test:**
+- Label: `Notepad`
+- Command: `notepad.exe`
+- Arguments: (leave empty)
+
+> **Note:** Some tools (Steam F12, GeForce Experience Alt+F1, Xbox Game Bar) use hotkeys only and don't support command-line execution.
+
 ## Requirements
 
 - **Playnite**: Version compatible with PlayniteSDK 6.12.0+

--- a/README.md
+++ b/README.md
@@ -120,29 +120,63 @@ Access settings through: **Playnite Menu** → **Add-ons** → **Extension setti
 - **Max Running Apps**: Limit number of apps displayed (1-50, default: 10)
 
 ### Shortcuts
-Configure custom shortcut buttons in the overlay that run shell commands:
+Configure custom shortcut buttons in the overlay that can run scripts or simulate keyboard presses:
 - **Add shortcuts** in settings (up to 10)
 - **Shortcuts appear** as buttons in a SHORTCUTS section in the overlay
-- **Click to execute** the configured command
+- **Click to execute** the configured action
 
-#### Example Configurations
+#### Action Types
 
-**ShareX Screenshot:**
-- Label: `Screenshot`
-- Command: `C:\Program Files\ShareX\ShareX.exe`
-- Arguments: `-screenshot`
+| Type | Description | Use Case |
+|------|-------------|----------|
+| **CommandLine** | Run a script or executable with arguments | Launch PowerShell scripts, batch files, external tools |
+| **SendInput** | Simulate a keyboard hotkey press | Trigger tools that only respond to hotkeys (Steam, OBS, etc.) |
 
-**OBS Recording:**
-- Label: `Record`
-- Command: `C:\Program Files\obs-studio\bin\64bit\obs64.exe`
-- Arguments: `--startrecording`
+#### CommandLine Examples
 
-**Simple Test:**
+**Run a PowerShell script:**
+- Label: `Backup Saves`
+- Action: `CommandLine`
+- Command: `powershell.exe`
+- Arguments: `-ExecutionPolicy Bypass -File "C:\Scripts\backup-saves.ps1"`
+
+**Run a batch file:**
+- Label: `Clean Temp`
+- Action: `CommandLine`
+- Command: `C:\Scripts\clean-temp.bat`
+- Arguments: (leave empty)
+
+**Launch external tool:**
 - Label: `Notepad`
+- Action: `CommandLine`
 - Command: `notepad.exe`
 - Arguments: (leave empty)
 
-> **Note:** Some tools (Steam F12, GeForce Experience Alt+F1, Xbox Game Bar) use hotkeys only and don't support command-line execution.
+#### SendInput Examples (Screenshot/Recording)
+
+For tools that use hotkeys instead of command-line arguments:
+
+**Steam Screenshot:**
+- Label: `Screenshot`
+- Action: `SendInput`
+- Hotkey: `F12`
+
+**OBS Toggle Recording:**
+- Label: `Record`
+- Action: `SendInput`
+- Hotkey: `F9` (or your OBS hotkey setting)
+
+**GeForce Experience Screenshot:**
+- Label: `Screenshot`
+- Action: `SendInput`
+- Hotkey: `Alt+F1`
+
+**Xbox Game Bar Recording:**
+- Label: `Record`
+- Action: `SendInput`
+- Hotkey: `Win+Alt+R`
+
+> **Tip:** For SendInput, set the hotkey to match what's configured in the target application. Check Steam/OBS/GeForce Experience settings to find or customize their screenshot/recording hotkeys.
 
 ## Requirements
 

--- a/src/OverlayPlugin/Converters/EnumToVisibilityConverter.cs
+++ b/src/OverlayPlugin/Converters/EnumToVisibilityConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace PlayniteOverlay.Converters;
+
+public sealed class EnumToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return Visibility.Collapsed;
+        }
+
+        return value.Equals(parameter) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/OverlayPlugin/Interop/HotkeyManager.cs
+++ b/src/OverlayPlugin/Interop/HotkeyManager.cs
@@ -16,6 +16,7 @@ internal sealed class HotkeyManager : IDisposable
     private const uint MOD_WIN = 0x0008;
 
     private static readonly ILogger logger = LogManager.GetLogger();
+    private static int nextId = 0xBEEE;
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
@@ -28,9 +29,9 @@ internal sealed class HotkeyManager : IDisposable
     private HwndSourceHook? hook;
     private Action? onHotkey;
 
-    public HotkeyManager(int id = 0xBEEF)
+    public HotkeyManager(int? id = null)
     {
-        this.id = id;
+        this.id = id ?? System.Threading.Interlocked.Increment(ref nextId);
     }
 
     public bool Register(string gesture, Action onHotkey)

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -81,21 +81,23 @@ internal static class NativeInput
 
     private static void AddModifierInputs(List<INPUT> inputs, ModifierKeys modifiers, bool keyDown)
     {
+        // keyDown=true means press (keyUp=false), keyDown=false means release (keyUp=true)
+        var keyUp = !keyDown;
         if (modifiers.HasFlag(ModifierKeys.Control))
         {
-            inputs.Add(CreateKeyInput(0x11, keyDown));
+            inputs.Add(CreateKeyInput(0x11, keyUp));
         }
         if (modifiers.HasFlag(ModifierKeys.Shift))
         {
-            inputs.Add(CreateKeyInput(0x10, keyDown));
+            inputs.Add(CreateKeyInput(0x10, keyUp));
         }
         if (modifiers.HasFlag(ModifierKeys.Alt))
         {
-            inputs.Add(CreateKeyInput(0x12, keyDown));
+            inputs.Add(CreateKeyInput(0x12, keyUp));
         }
         if (modifiers.HasFlag(ModifierKeys.Windows))
         {
-            inputs.Add(CreateKeyInput(0x5B, keyDown));
+            inputs.Add(CreateKeyInput(0x5B, keyUp));
         }
     }
 

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -9,40 +9,6 @@ namespace PlayniteOverlay.Interop;
 internal static class NativeInput
 {
     private static readonly ILogger logger = LogManager.GetLogger();
-    
-    // MapVirtualKey mapping types
-    private const uint MAPVK_VK_TO_VSC = 0;
-    
-    // Keyboard input flags
-    private const uint KEYEVENTF_KEYUP = 0x0002;
-    private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
-    private const uint KEYEVENTF_SCANCODE = 0x0008;
-
-    // Extended keys that need KEYEVENTF_EXTENDEDKEY flag
-    private static readonly HashSet<ushort> ExtendedKeys = new()
-    {
-        0x11, // VK_CONTROL
-        0x12, // VK_MENU (Alt)
-        0x10, // VK_SHIFT (for right shift)
-        0x21, // VK_PRIOR (Page Up)
-        0x22, // VK_NEXT (Page Down)
-        0x23, // VK_END
-        0x24, // VK_HOME
-        0x25, // VK_LEFT
-        0x26, // VK_UP
-        0x27, // VK_RIGHT
-        0x28, // VK_DOWN
-        0x2D, // VK_INSERT
-        0x2E, // VK_DELETE
-        0x5B, // VK_LWIN
-        0x5C, // VK_RWIN
-        0x6A, // VK_MULTIPLY
-        0x6B, // VK_ADD
-        0x6D, // VK_SUBTRACT
-        0x6E, // VK_DECIMAL
-        0x6F, // VK_DIVIDE
-        0x90, // VK_NUMLOCK
-    };
 
     public static void SendHotkey(string? gesture)
     {
@@ -66,107 +32,25 @@ internal static class NativeInput
         }
 
         var vk = (ushort)KeyInterop.VirtualKeyFromKey(key);
-        var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
-        var inputs = BuildInputs(modifiers, vk, scan);
+        var inputs = BuildInputs(modifiers, vk);
         if (inputs.Count == 0)
         {
             logger.Warn($"SendHotkey produced no inputs for '{gesture}'.");
             return;
         }
 
-        logger.Info($"SendHotkey: gesture='{gesture}', vk=0x{vk:X2}, scan=0x{scan:X2}, inputCount={inputs.Count}");
+        logger.Info($"SendHotkey: gesture='{gesture}', vk=0x{vk:X2}, inputCount={inputs.Count}");
 
-        // Try SendInput first
-        var result = SendInput((uint)inputs.Count, inputs.ToArray(), INPUT.Size);
+        var result = SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf(typeof(INPUT)));
         if (result == 0)
         {
             var error = Marshal.GetLastWin32Error();
-            logger.Warn($"SendInput failed for '{gesture}'. Win32Error={error}. Trying keybd_event fallback...");
-            
-            // Fallback to keybd_event
-            SendHotkeyViaKeybdEvent(modifiers, vk, scan);
+            logger.Warn($"SendHotkey failed for '{gesture}'. Win32Error={error}.");
         }
         else
         {
             logger.Info($"SendHotkey success: sent {result} inputs for '{gesture}'");
         }
-    }
-
-    private static void SendHotkeyViaKeybdEvent(ModifierKeys modifiers, ushort vk, ushort scan)
-    {
-        try
-        {
-            var isExtended = IsExtendedKey(vk);
-            var flagsDown = KEYEVENTF_SCANCODE | (isExtended ? KEYEVENTF_EXTENDEDKEY : 0);
-            var flagsUp = flagsDown | KEYEVENTF_KEYUP;
-
-            // Press modifiers
-            if (modifiers.HasFlag(ModifierKeys.Control))
-            {
-                var modVk = (byte)0x11;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsDown | KEYEVENTF_EXTENDEDKEY, 0);
-            }
-            if (modifiers.HasFlag(ModifierKeys.Shift))
-            {
-                var modVk = (byte)0x10;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsDown, 0);
-            }
-            if (modifiers.HasFlag(ModifierKeys.Alt))
-            {
-                var modVk = (byte)0x12;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsDown | KEYEVENTF_EXTENDEDKEY, 0);
-            }
-            if (modifiers.HasFlag(ModifierKeys.Windows))
-            {
-                var modVk = (byte)0x5B;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsDown | KEYEVENTF_EXTENDEDKEY, 0);
-            }
-
-            // Press and release main key
-            keybd_event((byte)vk, (byte)scan, flagsDown, 0);
-            keybd_event((byte)vk, (byte)scan, flagsUp, 0);
-
-            // Release modifiers (reverse order)
-            if (modifiers.HasFlag(ModifierKeys.Windows))
-            {
-                var modVk = (byte)0x5B;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsUp | KEYEVENTF_EXTENDEDKEY, 0);
-            }
-            if (modifiers.HasFlag(ModifierKeys.Alt))
-            {
-                var modVk = (byte)0x12;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsUp | KEYEVENTF_EXTENDEDKEY, 0);
-            }
-            if (modifiers.HasFlag(ModifierKeys.Shift))
-            {
-                var modVk = (byte)0x10;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsUp, 0);
-            }
-            if (modifiers.HasFlag(ModifierKeys.Control))
-            {
-                var modVk = (byte)0x11;
-                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
-                keybd_event(modVk, modScan, flagsUp | KEYEVENTF_EXTENDEDKEY, 0);
-            }
-
-            logger.Info($"SendHotkey: keybd_event fallback completed for vk=0x{vk:X2}");
-        }
-        catch (Exception ex)
-        {
-            logger.Error(ex, $"keybd_event fallback failed: {ex.Message}");
-        }
-    }
-
-    private static bool IsExtendedKey(ushort vk)
-    {
-        return ExtendedKeys.Contains(vk);
     }
 
     private static Key? KeyFromString(string keyToken)
@@ -191,59 +75,38 @@ internal static class NativeInput
         }
     }
 
-    private static List<INPUT> BuildInputs(ModifierKeys modifiers, ushort vk, ushort scan)
+    private static List<INPUT> BuildInputs(ModifierKeys modifiers, ushort vk)
     {
         var inputs = new List<INPUT>();
-        var isExtended = IsExtendedKey(vk);
-        
-        // Press modifiers
         AddModifierInputs(inputs, modifiers, true);
-        
-        // Press and release main key with KEYEVENTF_SCANCODE (critical for games/OBS)
-        inputs.Add(CreateKeyInput(vk, scan, false, isExtended));
-        inputs.Add(CreateKeyInput(vk, scan, true, isExtended));
-        
-        // Release modifiers
+        inputs.Add(CreateKeyInput(vk, false));
+        inputs.Add(CreateKeyInput(vk, true));
         AddModifierInputs(inputs, modifiers, false);
-        
         return inputs;
     }
 
     private static void AddModifierInputs(List<INPUT> inputs, ModifierKeys modifiers, bool keyDown)
     {
-        // All modifier keys are extended keys
         if (modifiers.HasFlag(ModifierKeys.Control))
         {
-            var vk = (ushort)0x11;
-            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
-            inputs.Add(CreateKeyInput(vk, scan, !keyDown, true));
+            inputs.Add(CreateKeyInput(0x11, !keyDown));
         }
         if (modifiers.HasFlag(ModifierKeys.Shift))
         {
-            var vk = (ushort)0x10;
-            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
-            inputs.Add(CreateKeyInput(vk, scan, !keyDown, false));
+            inputs.Add(CreateKeyInput(0x10, !keyDown));
         }
         if (modifiers.HasFlag(ModifierKeys.Alt))
         {
-            var vk = (ushort)0x12;
-            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
-            inputs.Add(CreateKeyInput(vk, scan, !keyDown, true));
+            inputs.Add(CreateKeyInput(0x12, !keyDown));
         }
         if (modifiers.HasFlag(ModifierKeys.Windows))
         {
-            var vk = (ushort)0x5B;
-            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
-            inputs.Add(CreateKeyInput(vk, scan, !keyDown, true));
+            inputs.Add(CreateKeyInput(0x5B, !keyDown));
         }
     }
 
-    private static INPUT CreateKeyInput(ushort vk, ushort scan, bool keyUp, bool isExtended)
+    private static INPUT CreateKeyInput(ushort vk, bool keyUp)
     {
-        uint flags = KEYEVENTF_SCANCODE; // Always use scancode - critical for games
-        if (isExtended) flags |= KEYEVENTF_EXTENDEDKEY;
-        if (keyUp) flags |= KEYEVENTF_KEYUP;
-
         return new INPUT
         {
             type = 1,
@@ -251,60 +114,31 @@ internal static class NativeInput
             {
                 ki = new KEYBDINPUT
                 {
-                    wVk = 0,
-                    wScan = scan,
-                    dwFlags = flags,
+                    wVk = vk,
+                    wScan = 0,
+                    dwFlags = keyUp ? 0x0002u : 0u,
                     time = 0,
-                    dwExtraInfo = UIntPtr.Zero
+                    dwExtraInfo = IntPtr.Zero
                 }
             }
         };
     }
 
-    #region Native Methods
-
-    [DllImport("user32.dll")]
-    private static extern uint MapVirtualKey(uint uCode, uint uMapType);
-
     [DllImport("user32.dll", SetLastError = true)]
     private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
-
-    [DllImport("user32.dll")]
-    private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
-
-    #endregion
-
-    #region Native Structures
 
     [StructLayout(LayoutKind.Sequential)]
     private struct INPUT
     {
         public uint type;
         public InputUnion U;
-
-        public static readonly int Size = Marshal.SizeOf(typeof(INPUT));
     }
 
     [StructLayout(LayoutKind.Explicit)]
     private struct InputUnion
     {
         [FieldOffset(0)]
-        public MOUSEINPUT mi;
-        [FieldOffset(0)]
         public KEYBDINPUT ki;
-        [FieldOffset(0)]
-        public HARDWAREINPUT hi;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct MOUSEINPUT
-    {
-        public int dx;
-        public int dy;
-        public uint mouseData;
-        public uint dwFlags;
-        public uint time;
-        public UIntPtr dwExtraInfo;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -314,16 +148,6 @@ internal static class NativeInput
         public ushort wScan;
         public uint dwFlags;
         public uint time;
-        public UIntPtr dwExtraInfo;
+        public IntPtr dwExtraInfo;
     }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct HARDWAREINPUT
-    {
-        public uint uMsg;
-        public ushort wParamL;
-        public ushort wParamH;
-    }
-
-    #endregion
 }

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -106,8 +106,16 @@ internal static class NativeInput
     {
         var inputs = new List<INPUT32>();
         int inputSize = Marshal.SizeOf(typeof(INPUT32));
+        const int expectedInputSize = 28;
 
         logger.Debug($"SendHotkey32: inputSize={inputSize}, vk=0x{vk:X2}, modifiers={modifiers}");
+
+        if (inputSize != expectedInputSize)
+        {
+            logger.Warn($"SendHotkey32: INPUT size mismatch (expected {expectedInputSize}, got {inputSize}). Falling back to keybd_event.");
+            SendHotkeyViaKeybdEvent(modifiers, vk);
+            return;
+        }
 
         // 1. Press modifiers
         AddModifierInputs32(inputs, modifiers, keyDown: true);
@@ -118,6 +126,8 @@ internal static class NativeInput
             if (sent == 0)
             {
                 logger.Warn($"SendHotkey32: SendInput failed for modifiers, Win32Error={Marshal.GetLastWin32Error()}");
+                SendHotkeyViaKeybdEvent(modifiers, vk);
+                return;
             }
             Thread.Sleep(ModifierDelayMs);
         }
@@ -129,6 +139,8 @@ internal static class NativeInput
         if (sentKeyDown == 0)
         {
             logger.Warn($"SendHotkey32: SendInput failed for key down, Win32Error={Marshal.GetLastWin32Error()}");
+            SendHotkeyViaKeybdEvent(modifiers, vk);
+            return;
         }
         Thread.Sleep(KeyHoldDelayMs);
 
@@ -139,6 +151,8 @@ internal static class NativeInput
         if (sentKeyUp == 0)
         {
             logger.Warn($"SendHotkey32: SendInput failed for key up, Win32Error={Marshal.GetLastWin32Error()}");
+            SendHotkeyViaKeybdEvent(modifiers, vk);
+            return;
         }
         Thread.Sleep(ModifierDelayMs);
 
@@ -151,6 +165,8 @@ internal static class NativeInput
             if (sentModsUp == 0)
             {
                 logger.Warn($"SendHotkey32: SendInput failed for modifiers up, Win32Error={Marshal.GetLastWin32Error()}");
+                SendHotkeyViaKeybdEvent(modifiers, vk);
+                return;
             }
         }
 
@@ -161,8 +177,16 @@ internal static class NativeInput
     {
         var inputs = new List<INPUT64>();
         int inputSize = Marshal.SizeOf(typeof(INPUT64));
+        const int expectedInputSize = 40;
 
         logger.Debug($"SendHotkey64: inputSize={inputSize}, vk=0x{vk:X2}, modifiers={modifiers}");
+
+        if (inputSize != expectedInputSize)
+        {
+            logger.Warn($"SendHotkey64: INPUT size mismatch (expected {expectedInputSize}, got {inputSize}). Falling back to keybd_event.");
+            SendHotkeyViaKeybdEvent(modifiers, vk);
+            return;
+        }
 
         // 1. Press modifiers
         AddModifierInputs64(inputs, modifiers, keyDown: true);
@@ -173,6 +197,8 @@ internal static class NativeInput
             if (sent == 0)
             {
                 logger.Warn($"SendHotkey64: SendInput failed for modifiers, Win32Error={Marshal.GetLastWin32Error()}");
+                SendHotkeyViaKeybdEvent(modifiers, vk);
+                return;
             }
             Thread.Sleep(ModifierDelayMs);
         }
@@ -184,6 +210,8 @@ internal static class NativeInput
         if (sentKeyDown == 0)
         {
             logger.Warn($"SendHotkey64: SendInput failed for key down, Win32Error={Marshal.GetLastWin32Error()}");
+            SendHotkeyViaKeybdEvent(modifiers, vk);
+            return;
         }
         Thread.Sleep(KeyHoldDelayMs);
 
@@ -194,6 +222,8 @@ internal static class NativeInput
         if (sentKeyUp == 0)
         {
             logger.Warn($"SendHotkey64: SendInput failed for key up, Win32Error={Marshal.GetLastWin32Error()}");
+            SendHotkeyViaKeybdEvent(modifiers, vk);
+            return;
         }
         Thread.Sleep(ModifierDelayMs);
 
@@ -206,6 +236,8 @@ internal static class NativeInput
             if (sentModsUp == 0)
             {
                 logger.Warn($"SendHotkey64: SendInput failed for modifiers up, Win32Error={Marshal.GetLastWin32Error()}");
+                SendHotkeyViaKeybdEvent(modifiers, vk);
+                return;
             }
         }
 

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -14,6 +14,12 @@ internal static class NativeInput
     private const uint KEYEVENTF_KEYUP = 0x0002;
     private const int INPUT_KEYBOARD = 1;
 
+    // Virtual key codes for modifiers
+    private const byte VK_CONTROL = 0x11;
+    private const byte VK_SHIFT = 0x10;
+    private const byte VK_MENU = 0x12;    // Alt
+    private const byte VK_LWIN = 0x5B;
+
     private const int ModifierDelayMs = 10;      // Delay after modifier press/release
     private const int KeyHoldDelayMs = 50;       // How long to hold main key (must be > 25ms for OBS polling)
 
@@ -208,13 +214,13 @@ internal static class NativeInput
         {
             // Press modifiers
             if (modifiers.HasFlag(ModifierKeys.Control))
-                keybd_event(0x11, 0, 0, 0);
+                keybd_event(VK_CONTROL, 0, 0, 0);
             if (modifiers.HasFlag(ModifierKeys.Shift))
-                keybd_event(0x10, 0, 0, 0);
+                keybd_event(VK_SHIFT, 0, 0, 0);
             if (modifiers.HasFlag(ModifierKeys.Alt))
-                keybd_event(0x12, 0, 0, 0);
+                keybd_event(VK_MENU, 0, 0, 0);
             if (modifiers.HasFlag(ModifierKeys.Windows))
-                keybd_event(0x5B, 0, 0, 0);
+                keybd_event(VK_LWIN, 0, 0, 0);
 
             Thread.Sleep(ModifierDelayMs);
 
@@ -228,13 +234,13 @@ internal static class NativeInput
 
             // Release modifiers (reverse order)
             if (modifiers.HasFlag(ModifierKeys.Windows))
-                keybd_event(0x5B, 0, KEYEVENTF_KEYUP, 0);
+                keybd_event(VK_LWIN, 0, KEYEVENTF_KEYUP, 0);
             if (modifiers.HasFlag(ModifierKeys.Alt))
-                keybd_event(0x12, 0, KEYEVENTF_KEYUP, 0);
+                keybd_event(VK_MENU, 0, KEYEVENTF_KEYUP, 0);
             if (modifiers.HasFlag(ModifierKeys.Shift))
-                keybd_event(0x10, 0, KEYEVENTF_KEYUP, 0);
+                keybd_event(VK_SHIFT, 0, KEYEVENTF_KEYUP, 0);
             if (modifiers.HasFlag(ModifierKeys.Control))
-                keybd_event(0x11, 0, KEYEVENTF_KEYUP, 0);
+                keybd_event(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0);
 
             logger.Info($"SendHotkey: keybd_event fallback completed for vk=0x{vk:X2}");
         }
@@ -273,13 +279,13 @@ internal static class NativeInput
         var flags = keyDown ? 0u : KEYEVENTF_KEYUP;
 
         if (modifiers.HasFlag(ModifierKeys.Control))
-            inputs.Add(CreateKeyInput32WithFlags(0x11, flags));
+            inputs.Add(CreateKeyInput32WithFlags((ushort)VK_CONTROL, flags));
         if (modifiers.HasFlag(ModifierKeys.Shift))
-            inputs.Add(CreateKeyInput32WithFlags(0x10, flags));
+            inputs.Add(CreateKeyInput32WithFlags((ushort)VK_SHIFT, flags));
         if (modifiers.HasFlag(ModifierKeys.Alt))
-            inputs.Add(CreateKeyInput32WithFlags(0x12, flags));
+            inputs.Add(CreateKeyInput32WithFlags((ushort)VK_MENU, flags));
         if (modifiers.HasFlag(ModifierKeys.Windows))
-            inputs.Add(CreateKeyInput32WithFlags(0x5B, flags));
+            inputs.Add(CreateKeyInput32WithFlags((ushort)VK_LWIN, flags));
     }
 
     private static INPUT32 CreateKeyInput32(ushort vk, bool keyUp)
@@ -312,13 +318,13 @@ internal static class NativeInput
         var flags = keyDown ? 0u : KEYEVENTF_KEYUP;
 
         if (modifiers.HasFlag(ModifierKeys.Control))
-            inputs.Add(CreateKeyInput64WithFlags(0x11, flags));
+            inputs.Add(CreateKeyInput64WithFlags((ushort)VK_CONTROL, flags));
         if (modifiers.HasFlag(ModifierKeys.Shift))
-            inputs.Add(CreateKeyInput64WithFlags(0x10, flags));
+            inputs.Add(CreateKeyInput64WithFlags((ushort)VK_SHIFT, flags));
         if (modifiers.HasFlag(ModifierKeys.Alt))
-            inputs.Add(CreateKeyInput64WithFlags(0x12, flags));
+            inputs.Add(CreateKeyInput64WithFlags((ushort)VK_MENU, flags));
         if (modifiers.HasFlag(ModifierKeys.Windows))
-            inputs.Add(CreateKeyInput64WithFlags(0x5B, flags));
+            inputs.Add(CreateKeyInput64WithFlags((ushort)VK_LWIN, flags));
     }
 
     private static INPUT64 CreateKeyInput64(ushort vk, bool keyUp)

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Playnite.SDK;
 using System.Windows.Input;
 
@@ -11,7 +12,13 @@ internal static class NativeInput
     private static readonly ILogger logger = LogManager.GetLogger();
 
     private const uint KEYEVENTF_KEYUP = 0x0002;
+    private const uint INPUT_KEYBOARD = 1;
 
+    // Delays for polling-based hotkey detector compatibility (e.g., OBS)
+    // OBS polls GetAsyncKeyState every 25ms, so we need delays to ensure
+    // the polling thread sees the key down state before key up is processed
+    private const int ModifierDelayMs = 10;      // Delay after modifier press/release
+    private const int KeyHoldDelayMs = 50;       // How long to hold main key (must be > 25ms for OBS polling)
     public static void SendHotkey(string? gesture)
     {
         if (string.IsNullOrWhiteSpace(gesture))
@@ -34,27 +41,63 @@ internal static class NativeInput
         }
 
         var vk = (ushort)KeyInterop.VirtualKeyFromKey(key);
-        var inputs = BuildInputs(modifiers, vk);
-        if (inputs.Count == 0)
+        logger.Info($"SendHotkey: gesture='{gesture}', vk=0x{vk:X2}");
+
+        // Use SendInput with delays between key events for OBS compatibility
+        // OBS polls GetAsyncKeyState every 25ms, so we need delays to ensure
+        // the polling thread sees the key down state before key up is processed
+        SendHotkeyWithDelays(modifiers, vk);
+    }
+
+    /// <summary>
+    /// Sends hotkey with delays between key events to ensure polling-based
+    /// hotkey detectors (like OBS) can detect the key down state.
+    /// </summary>
+    private static void SendHotkeyWithDelays(ModifierKeys modifiers, ushort vk)
+    {
+        try
         {
-            logger.Warn($"SendHotkey produced no inputs for '{gesture}'.");
-            return;
+            var inputs = new List<INPUT>();
+            int inputSize = Marshal.SizeOf(typeof(INPUT));
+
+            // 1. Press modifiers
+            AddModifierInputs(inputs, modifiers, keyDown: true);
+            if (inputs.Count > 0)
+            {
+                SendInput((uint)inputs.Count, inputs.ToArray(), inputSize);
+                Thread.Sleep(ModifierDelayMs);
+            }
+
+            // 2. Press main key
+            inputs.Clear();
+            inputs.Add(CreateKeyInput(vk, keyUp: false));
+            SendInput(1, inputs.ToArray(), inputSize);
+
+            // 3. Wait long enough for polling detectors to see the key down
+            // OBS polls every 25ms, so 50ms ensures at least one poll sees it
+            Thread.Sleep(KeyHoldDelayMs);
+
+            // 4. Release main key
+            inputs.Clear();
+            inputs.Add(CreateKeyInput(vk, keyUp: true));
+            SendInput(1, inputs.ToArray(), inputSize);
+            Thread.Sleep(ModifierDelayMs);
+
+            // 5. Release modifiers
+            inputs.Clear();
+            AddModifierInputs(inputs, modifiers, keyDown: false);
+            if (inputs.Count > 0)
+            {
+                SendInput((uint)inputs.Count, inputs.ToArray(), inputSize);
+            }
+
+            logger.Info($"SendHotkeyWithDelays: completed for vk=0x{vk:X2}");
         }
-
-        logger.Info($"SendHotkey: gesture='{gesture}', vk=0x{vk:X2}, inputCount={inputs.Count}");
-
-        var result = SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf(typeof(INPUT)));
-        if (result == 0)
+        catch (Exception ex)
         {
-            var error = Marshal.GetLastWin32Error();
-            logger.Warn($"SendInput failed for '{gesture}'. Win32Error={error}. Trying keybd_event fallback...");
-
+            logger.Error(ex, $"SendHotkeyWithDelays failed: {ex.Message}");
             // Fallback to keybd_event
             SendHotkeyViaKeybdEvent(modifiers, vk);
-        }
-        else
-        {
-            logger.Info($"SendHotkey success: sent {result} inputs for '{gesture}'");
         }
     }
 
@@ -72,9 +115,15 @@ internal static class NativeInput
             if (modifiers.HasFlag(ModifierKeys.Windows))
                 keybd_event(0x5B, 0, 0, 0);
 
-            // Press and release main key
+            Thread.Sleep(ModifierDelayMs);
+
+            // Press main key
             keybd_event((byte)vk, 0, 0, 0);
+            Thread.Sleep(KeyHoldDelayMs);
+
+            // Release main key
             keybd_event((byte)vk, 0, KEYEVENTF_KEYUP, 0);
+            Thread.Sleep(ModifierDelayMs);
 
             // Release modifiers (reverse order)
             if (modifiers.HasFlag(ModifierKeys.Windows))
@@ -116,48 +165,39 @@ internal static class NativeInput
         }
     }
 
-    private static List<INPUT> BuildInputs(ModifierKeys modifiers, ushort vk)
-    {
-        var inputs = new List<INPUT>();
-        AddModifierInputs(inputs, modifiers, true);
-        inputs.Add(CreateKeyInput(vk, false));
-        inputs.Add(CreateKeyInput(vk, true));
-        AddModifierInputs(inputs, modifiers, false);
-        return inputs;
-    }
-
     private static void AddModifierInputs(List<INPUT> inputs, ModifierKeys modifiers, bool keyDown)
     {
+        // Note: When keyDown=true, we add key-down inputs
+        // When keyDown=false, we add key-up inputs
+        var flags = keyDown ? 0u : KEYEVENTF_KEYUP;
+
         if (modifiers.HasFlag(ModifierKeys.Control))
-        {
-            inputs.Add(CreateKeyInput(0x11, !keyDown));
-        }
+            inputs.Add(CreateKeyInputWithFlags(0x11, flags));
         if (modifiers.HasFlag(ModifierKeys.Shift))
-        {
-            inputs.Add(CreateKeyInput(0x10, !keyDown));
-        }
+            inputs.Add(CreateKeyInputWithFlags(0x10, flags));
         if (modifiers.HasFlag(ModifierKeys.Alt))
-        {
-            inputs.Add(CreateKeyInput(0x12, !keyDown));
-        }
+            inputs.Add(CreateKeyInputWithFlags(0x12, flags));
         if (modifiers.HasFlag(ModifierKeys.Windows))
-        {
-            inputs.Add(CreateKeyInput(0x5B, !keyDown));
-        }
+            inputs.Add(CreateKeyInputWithFlags(0x5B, flags));
     }
 
     private static INPUT CreateKeyInput(ushort vk, bool keyUp)
     {
+        return CreateKeyInputWithFlags(vk, keyUp ? KEYEVENTF_KEYUP : 0u);
+    }
+
+    private static INPUT CreateKeyInputWithFlags(ushort vk, uint flags)
+    {
         return new INPUT
         {
-            type = 1,
+            type = INPUT_KEYBOARD,
             U = new InputUnion
             {
                 ki = new KEYBDINPUT
                 {
                     wVk = vk,
                     wScan = 0,
-                    dwFlags = keyUp ? KEYEVENTF_KEYUP : 0u,
+                    dwFlags = flags,
                     time = 0,
                     dwExtraInfo = IntPtr.Zero
                 }

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -251,7 +251,7 @@ internal static class NativeInput
             {
                 ki = new KEYBDINPUT
                 {
-                    wVk = vk,
+                    wVk = 0,
                     wScan = scan,
                     dwFlags = flags,
                     time = 0,

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -39,7 +39,7 @@ internal static class NativeInput
             return;
         }
 
-        var result = SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf(typeof(INPUT)));
+        var result = SendInput((uint)inputs.Count, inputs.ToArray(), INPUT.Size);
         if (result == 0)
         {
             var error = Marshal.GetLastWin32Error();
@@ -83,19 +83,19 @@ internal static class NativeInput
     {
         if (modifiers.HasFlag(ModifierKeys.Control))
         {
-            inputs.Add(CreateKeyInput(0x11, !keyDown));
+            inputs.Add(CreateKeyInput(0x11, keyDown));
         }
         if (modifiers.HasFlag(ModifierKeys.Shift))
         {
-            inputs.Add(CreateKeyInput(0x10, !keyDown));
+            inputs.Add(CreateKeyInput(0x10, keyDown));
         }
         if (modifiers.HasFlag(ModifierKeys.Alt))
         {
-            inputs.Add(CreateKeyInput(0x12, !keyDown));
+            inputs.Add(CreateKeyInput(0x12, keyDown));
         }
         if (modifiers.HasFlag(ModifierKeys.Windows))
         {
-            inputs.Add(CreateKeyInput(0x5B, !keyDown));
+            inputs.Add(CreateKeyInput(0x5B, keyDown));
         }
     }
 
@@ -112,7 +112,7 @@ internal static class NativeInput
                     wScan = 0,
                     dwFlags = keyUp ? 0x0002u : 0u,
                     time = 0,
-                    dwExtraInfo = IntPtr.Zero
+                    dwExtraInfo = UIntPtr.Zero
                 }
             }
         };
@@ -126,13 +126,30 @@ internal static class NativeInput
     {
         public uint type;
         public InputUnion U;
+
+        public static readonly int Size = Marshal.SizeOf(typeof(INPUT));
     }
 
     [StructLayout(LayoutKind.Explicit)]
     private struct InputUnion
     {
         [FieldOffset(0)]
+        public MOUSEINPUT mi;
+        [FieldOffset(0)]
         public KEYBDINPUT ki;
+        [FieldOffset(0)]
+        public HARDWAREINPUT hi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MOUSEINPUT
+    {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -142,6 +159,14 @@ internal static class NativeInput
         public ushort wScan;
         public uint dwFlags;
         public uint time;
-        public IntPtr dwExtraInfo;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HARDWAREINPUT
+    {
+        public uint uMsg;
+        public ushort wParamL;
+        public ushort wParamH;
     }
 }

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -10,7 +10,39 @@ internal static class NativeInput
 {
     private static readonly ILogger logger = LogManager.GetLogger();
     
+    // MapVirtualKey mapping types
     private const uint MAPVK_VK_TO_VSC = 0;
+    
+    // Keyboard input flags
+    private const uint KEYEVENTF_KEYUP = 0x0002;
+    private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
+    private const uint KEYEVENTF_SCANCODE = 0x0008;
+
+    // Extended keys that need KEYEVENTF_EXTENDEDKEY flag
+    private static readonly HashSet<ushort> ExtendedKeys = new()
+    {
+        0x11, // VK_CONTROL
+        0x12, // VK_MENU (Alt)
+        0x10, // VK_SHIFT (for right shift)
+        0x21, // VK_PRIOR (Page Up)
+        0x22, // VK_NEXT (Page Down)
+        0x23, // VK_END
+        0x24, // VK_HOME
+        0x25, // VK_LEFT
+        0x26, // VK_UP
+        0x27, // VK_RIGHT
+        0x28, // VK_DOWN
+        0x2D, // VK_INSERT
+        0x2E, // VK_DELETE
+        0x5B, // VK_LWIN
+        0x5C, // VK_RWIN
+        0x6A, // VK_MULTIPLY
+        0x6B, // VK_ADD
+        0x6D, // VK_SUBTRACT
+        0x6E, // VK_DECIMAL
+        0x6F, // VK_DIVIDE
+        0x90, // VK_NUMLOCK
+    };
 
     public static void SendHotkey(string? gesture)
     {
@@ -42,18 +74,99 @@ internal static class NativeInput
             return;
         }
 
-        logger.Info($"SendHotkey: gesture='{gesture}', modifiers={modifiers}, vk=0x{vk:X2}, scan=0x{scan:X2}, inputCount={inputs.Count}");
+        logger.Info($"SendHotkey: gesture='{gesture}', vk=0x{vk:X2}, scan=0x{scan:X2}, inputCount={inputs.Count}");
 
+        // Try SendInput first
         var result = SendInput((uint)inputs.Count, inputs.ToArray(), INPUT.Size);
         if (result == 0)
         {
             var error = Marshal.GetLastWin32Error();
-            logger.Warn($"SendHotkey failed for '{gesture}'. Win32Error={error}.");
+            logger.Warn($"SendInput failed for '{gesture}'. Win32Error={error}. Trying keybd_event fallback...");
+            
+            // Fallback to keybd_event
+            SendHotkeyViaKeybdEvent(modifiers, vk, scan);
         }
         else
         {
             logger.Info($"SendHotkey success: sent {result} inputs for '{gesture}'");
         }
+    }
+
+    private static void SendHotkeyViaKeybdEvent(ModifierKeys modifiers, ushort vk, ushort scan)
+    {
+        try
+        {
+            var isExtended = IsExtendedKey(vk);
+            var flagsDown = KEYEVENTF_SCANCODE | (isExtended ? KEYEVENTF_EXTENDEDKEY : 0);
+            var flagsUp = flagsDown | KEYEVENTF_KEYUP;
+
+            // Press modifiers
+            if (modifiers.HasFlag(ModifierKeys.Control))
+            {
+                var modVk = (byte)0x11;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsDown | KEYEVENTF_EXTENDEDKEY, 0);
+            }
+            if (modifiers.HasFlag(ModifierKeys.Shift))
+            {
+                var modVk = (byte)0x10;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsDown, 0);
+            }
+            if (modifiers.HasFlag(ModifierKeys.Alt))
+            {
+                var modVk = (byte)0x12;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsDown | KEYEVENTF_EXTENDEDKEY, 0);
+            }
+            if (modifiers.HasFlag(ModifierKeys.Windows))
+            {
+                var modVk = (byte)0x5B;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsDown | KEYEVENTF_EXTENDEDKEY, 0);
+            }
+
+            // Press and release main key
+            keybd_event((byte)vk, (byte)scan, flagsDown, 0);
+            keybd_event((byte)vk, (byte)scan, flagsUp, 0);
+
+            // Release modifiers (reverse order)
+            if (modifiers.HasFlag(ModifierKeys.Windows))
+            {
+                var modVk = (byte)0x5B;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsUp | KEYEVENTF_EXTENDEDKEY, 0);
+            }
+            if (modifiers.HasFlag(ModifierKeys.Alt))
+            {
+                var modVk = (byte)0x12;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsUp | KEYEVENTF_EXTENDEDKEY, 0);
+            }
+            if (modifiers.HasFlag(ModifierKeys.Shift))
+            {
+                var modVk = (byte)0x10;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsUp, 0);
+            }
+            if (modifiers.HasFlag(ModifierKeys.Control))
+            {
+                var modVk = (byte)0x11;
+                var modScan = (byte)MapVirtualKey(modVk, MAPVK_VK_TO_VSC);
+                keybd_event(modVk, modScan, flagsUp | KEYEVENTF_EXTENDEDKEY, 0);
+            }
+
+            logger.Info($"SendHotkey: keybd_event fallback completed for vk=0x{vk:X2}");
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, $"keybd_event fallback failed: {ex.Message}");
+        }
+    }
+
+    private static bool IsExtendedKey(ushort vk)
+    {
+        return ExtendedKeys.Contains(vk);
     }
 
     private static Key? KeyFromString(string keyToken)
@@ -81,40 +194,56 @@ internal static class NativeInput
     private static List<INPUT> BuildInputs(ModifierKeys modifiers, ushort vk, ushort scan)
     {
         var inputs = new List<INPUT>();
-        AddModifierInputs(inputs, modifiers, vk => (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC), true);
-        inputs.Add(CreateKeyInput(vk, scan, false));
-        inputs.Add(CreateKeyInput(vk, scan, true));
-        AddModifierInputs(inputs, modifiers, vk => (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC), false);
+        var isExtended = IsExtendedKey(vk);
+        
+        // Press modifiers
+        AddModifierInputs(inputs, modifiers, true);
+        
+        // Press and release main key with KEYEVENTF_SCANCODE (critical for games/OBS)
+        inputs.Add(CreateKeyInput(vk, scan, false, isExtended));
+        inputs.Add(CreateKeyInput(vk, scan, true, isExtended));
+        
+        // Release modifiers
+        AddModifierInputs(inputs, modifiers, false);
+        
         return inputs;
     }
 
-    private static void AddModifierInputs(List<INPUT> inputs, ModifierKeys modifiers, Func<ushort, ushort> getScan, bool keyDown)
+    private static void AddModifierInputs(List<INPUT> inputs, ModifierKeys modifiers, bool keyDown)
     {
-        var keyUp = !keyDown;
+        // All modifier keys are extended keys
         if (modifiers.HasFlag(ModifierKeys.Control))
         {
             var vk = (ushort)0x11;
-            inputs.Add(CreateKeyInput(vk, getScan(vk), keyUp));
+            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+            inputs.Add(CreateKeyInput(vk, scan, !keyDown, true));
         }
         if (modifiers.HasFlag(ModifierKeys.Shift))
         {
             var vk = (ushort)0x10;
-            inputs.Add(CreateKeyInput(vk, getScan(vk), keyUp));
+            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+            inputs.Add(CreateKeyInput(vk, scan, !keyDown, false));
         }
         if (modifiers.HasFlag(ModifierKeys.Alt))
         {
             var vk = (ushort)0x12;
-            inputs.Add(CreateKeyInput(vk, getScan(vk), keyUp));
+            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+            inputs.Add(CreateKeyInput(vk, scan, !keyDown, true));
         }
         if (modifiers.HasFlag(ModifierKeys.Windows))
         {
             var vk = (ushort)0x5B;
-            inputs.Add(CreateKeyInput(vk, getScan(vk), keyUp));
+            var scan = (ushort)MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+            inputs.Add(CreateKeyInput(vk, scan, !keyDown, true));
         }
     }
 
-    private static INPUT CreateKeyInput(ushort vk, ushort scan, bool keyUp)
+    private static INPUT CreateKeyInput(ushort vk, ushort scan, bool keyUp, bool isExtended)
     {
+        uint flags = KEYEVENTF_SCANCODE; // Always use scancode - critical for games
+        if (isExtended) flags |= KEYEVENTF_EXTENDEDKEY;
+        if (keyUp) flags |= KEYEVENTF_KEYUP;
+
         return new INPUT
         {
             type = 1,
@@ -124,7 +253,7 @@ internal static class NativeInput
                 {
                     wVk = vk,
                     wScan = scan,
-                    dwFlags = keyUp ? 0x0002u : 0u,
+                    dwFlags = flags,
                     time = 0,
                     dwExtraInfo = UIntPtr.Zero
                 }
@@ -132,11 +261,20 @@ internal static class NativeInput
         };
     }
 
+    #region Native Methods
+
     [DllImport("user32.dll")]
     private static extern uint MapVirtualKey(uint uCode, uint uMapType);
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    [DllImport("user32.dll")]
+    private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
+
+    #endregion
+
+    #region Native Structures
 
     [StructLayout(LayoutKind.Sequential)]
     private struct INPUT
@@ -186,4 +324,6 @@ internal static class NativeInput
         public ushort wParamL;
         public ushort wParamH;
     }
+
+    #endregion
 }

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -39,11 +39,17 @@ internal static class NativeInput
             return;
         }
 
+        logger.Info($"SendHotkey: gesture='{gesture}', modifiers={modifiers}, keyToken='{keyToken}', vk=0x{vk:X4}, inputCount={inputs.Count}");
+
         var result = SendInput((uint)inputs.Count, inputs.ToArray(), INPUT.Size);
         if (result == 0)
         {
             var error = Marshal.GetLastWin32Error();
             logger.Warn($"SendHotkey failed for '{gesture}'. Win32Error={error}.");
+        }
+        else
+        {
+            logger.Info($"SendHotkey success: sent {result} inputs for '{gesture}'");
         }
     }
 

--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Playnite.SDK;
+using System.Windows.Input;
+
+namespace PlayniteOverlay.Interop;
+
+internal static class NativeInput
+{
+    private static readonly ILogger logger = LogManager.GetLogger();
+
+    public static void SendHotkey(string? gesture)
+    {
+        if (string.IsNullOrWhiteSpace(gesture))
+        {
+            logger.Warn("SendHotkey called with empty gesture.");
+            return;
+        }
+
+        ParseGesture(gesture!, out var modifiers, out var keyToken);
+        if (keyToken == null)
+        {
+            logger.Warn($"SendHotkey could not parse key token from '{gesture}'.");
+            return;
+        }
+
+        if (KeyFromString(keyToken) is not Key key)
+        {
+            logger.Warn($"SendHotkey could not resolve key '{keyToken}' from '{gesture}'.");
+            return;
+        }
+
+        var vk = (ushort)KeyInterop.VirtualKeyFromKey(key);
+        var inputs = BuildInputs(modifiers, vk);
+        if (inputs.Count == 0)
+        {
+            logger.Warn($"SendHotkey produced no inputs for '{gesture}'.");
+            return;
+        }
+
+        var result = SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf(typeof(INPUT)));
+        if (result == 0)
+        {
+            var error = Marshal.GetLastWin32Error();
+            logger.Warn($"SendHotkey failed for '{gesture}'. Win32Error={error}.");
+        }
+    }
+
+    private static Key? KeyFromString(string keyToken)
+    {
+        var converter = new KeyConverter();
+        return converter.ConvertFromString(keyToken) is Key key ? key : null;
+    }
+
+    private static void ParseGesture(string gesture, out ModifierKeys modifiers, out string? keyToken)
+    {
+        modifiers = ModifierKeys.None;
+        keyToken = null;
+        var tokens = gesture.Split('+');
+        foreach (var raw in tokens)
+        {
+            var t = raw.Trim();
+            if (t.Equals("Ctrl", StringComparison.OrdinalIgnoreCase) || t.Equals("Control", StringComparison.OrdinalIgnoreCase)) modifiers |= ModifierKeys.Control;
+            else if (t.Equals("Alt", StringComparison.OrdinalIgnoreCase)) modifiers |= ModifierKeys.Alt;
+            else if (t.Equals("Shift", StringComparison.OrdinalIgnoreCase)) modifiers |= ModifierKeys.Shift;
+            else if (t.Equals("Win", StringComparison.OrdinalIgnoreCase) || t.Equals("Windows", StringComparison.OrdinalIgnoreCase)) modifiers |= ModifierKeys.Windows;
+            else keyToken = t;
+        }
+    }
+
+    private static List<INPUT> BuildInputs(ModifierKeys modifiers, ushort vk)
+    {
+        var inputs = new List<INPUT>();
+        AddModifierInputs(inputs, modifiers, true);
+        inputs.Add(CreateKeyInput(vk, false));
+        inputs.Add(CreateKeyInput(vk, true));
+        AddModifierInputs(inputs, modifiers, false);
+        return inputs;
+    }
+
+    private static void AddModifierInputs(List<INPUT> inputs, ModifierKeys modifiers, bool keyDown)
+    {
+        if (modifiers.HasFlag(ModifierKeys.Control))
+        {
+            inputs.Add(CreateKeyInput(0x11, !keyDown));
+        }
+        if (modifiers.HasFlag(ModifierKeys.Shift))
+        {
+            inputs.Add(CreateKeyInput(0x10, !keyDown));
+        }
+        if (modifiers.HasFlag(ModifierKeys.Alt))
+        {
+            inputs.Add(CreateKeyInput(0x12, !keyDown));
+        }
+        if (modifiers.HasFlag(ModifierKeys.Windows))
+        {
+            inputs.Add(CreateKeyInput(0x5B, !keyDown));
+        }
+    }
+
+    private static INPUT CreateKeyInput(ushort vk, bool keyUp)
+    {
+        return new INPUT
+        {
+            type = 1,
+            U = new InputUnion
+            {
+                ki = new KEYBDINPUT
+                {
+                    wVk = vk,
+                    wScan = 0,
+                    dwFlags = keyUp ? 0x0002u : 0u,
+                    time = 0,
+                    dwExtraInfo = IntPtr.Zero
+                }
+            }
+        };
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT
+    {
+        public uint type;
+        public InputUnion U;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion
+    {
+        [FieldOffset(0)]
+        public KEYBDINPUT ki;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+}

--- a/src/OverlayPlugin/Models/OverlayShortcut.cs
+++ b/src/OverlayPlugin/Models/OverlayShortcut.cs
@@ -86,8 +86,18 @@ public sealed class OverlayShortcut : INotifyPropertyChanged
     }
 }
 
+/// <summary>
+/// Defines the type of action a shortcut can perform.
+/// </summary>
 public enum ShortcutActionType
 {
+    /// <summary>
+    /// Execute a shell command or launch an executable.
+    /// </summary>
     CommandLine,
+    
+    /// <summary>
+    /// Simulate keyboard input (hotkey) using SendInput API.
+    /// </summary>
     SendInput
 }

--- a/src/OverlayPlugin/Models/OverlayShortcut.cs
+++ b/src/OverlayPlugin/Models/OverlayShortcut.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+
+namespace PlayniteOverlay.Models;
+
+/// <summary>
+/// Represents a custom shortcut command.
+/// </summary>
+public sealed class OverlayShortcut : INotifyPropertyChanged
+{
+    private ShortcutActionType actionType = ShortcutActionType.CommandLine;
+    private string label = string.Empty;
+    private string command = string.Empty;
+    private string arguments = string.Empty;
+    private string hotkey = string.Empty;
+
+    public ShortcutActionType ActionType
+    {
+        get => actionType;
+        set
+        {
+            if (actionType != value)
+            {
+                actionType = value;
+                OnPropertyChanged(nameof(ActionType));
+            }
+        }
+    }
+
+    public string Label
+    {
+        get => label;
+        set
+        {
+            if (label != value)
+            {
+                label = value;
+                OnPropertyChanged(nameof(Label));
+            }
+        }
+    }
+
+    public string Command
+    {
+        get => command;
+        set
+        {
+            if (command != value)
+            {
+                command = value;
+                OnPropertyChanged(nameof(Command));
+            }
+        }
+    }
+
+    public string Arguments
+    {
+        get => arguments;
+        set
+        {
+            if (arguments != value)
+            {
+                arguments = value;
+                OnPropertyChanged(nameof(Arguments));
+            }
+        }
+    }
+
+    public string Hotkey
+    {
+        get => hotkey;
+        set
+        {
+            if (hotkey != value)
+            {
+                hotkey = value;
+                OnPropertyChanged(nameof(Hotkey));
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+public enum ShortcutActionType
+{
+    CommandLine,
+    SendInput
+}

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -87,7 +87,6 @@ public class OverlayPlugin : GenericPlugin
             switcher.SetActiveApp(app);
         };
 
-
         // Start hotkey immediately (keyboard shortcut should always work)
         input.StartHotkey();
 
@@ -174,8 +173,7 @@ public class OverlayPlugin : GenericPlugin
     internal void ApplySettings(OverlaySettings newSettings)
     {
         input.ApplySettings(newSettings);
-        
-        
+
         // Apply controller always-active setting
         if (newSettings.ControllerAlwaysActive)
         {

--- a/src/OverlayPlugin/OverlayPlugin.cs
+++ b/src/OverlayPlugin/OverlayPlugin.cs
@@ -87,6 +87,7 @@ public class OverlayPlugin : GenericPlugin
             switcher.SetActiveApp(app);
         };
 
+
         // Start hotkey immediately (keyboard shortcut should always work)
         input.StartHotkey();
 
@@ -173,6 +174,7 @@ public class OverlayPlugin : GenericPlugin
     internal void ApplySettings(OverlaySettings newSettings)
     {
         input.ApplySettings(newSettings);
+        
         
         // Apply controller always-active setting
         if (newSettings.ControllerAlwaysActive)
@@ -281,7 +283,9 @@ public class OverlayPlugin : GenericPlugin
             SwitchAudioDevice,
             gameVolumeService,
             switcher.ActiveApp?.ProcessId,
-            switcher);
+            switcher,
+            settings.Settings,
+            settings.Settings.Shortcuts);
     }
 
     private void HandleExitGame()

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -516,7 +516,7 @@
                             <TextBlock Text="QUICK ACTIONS" FontSize="10" FontWeight="Bold" 
                                        Foreground="#888888" Margin="0,0,0,10"/>
                             
-                            <StackPanel x:Name="ShortcutsPanel" Orientation="Horizontal" />
+                            <WrapPanel x:Name="ShortcutsPanel" />
                         </StackPanel>
                     </Border>
                     

--- a/src/OverlayPlugin/OverlayWindow.xaml
+++ b/src/OverlayPlugin/OverlayWindow.xaml
@@ -19,7 +19,6 @@
                           HorizontalScrollBarVisibility="Disabled"
                           Focusable="False">
                 <StackPanel>
-                    <!-- Header -->
                     <Grid Margin="0,0,0,20">
                         <TextBlock Text="Playnite Overlay" FontSize="24" FontWeight="SemiBold" 
                                    Foreground="#EEEEEE" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
@@ -31,7 +30,6 @@
                         </StackPanel>
                     </Grid>
                     
-                    <!-- Current Game Section (collapsed when no game running) -->
                     <Border x:Name="CurrentGameSection" Background="#252525" CornerRadius="8" 
                             Padding="20" Margin="0,0,0,20" Visibility="Collapsed"
                             BorderThickness="2" BorderBrush="Transparent" Focusable="True">
@@ -43,13 +41,11 @@
                                 <ColumnDefinition Width="220"/>
                             </Grid.ColumnDefinitions>
                             
-                            <!-- Cover Image -->
                             <Border Grid.Column="0" Background="#1A1A1A" CornerRadius="6" 
                                     Width="120" Height="160" HorizontalAlignment="Left" VerticalAlignment="Top">
                                 <Image x:Name="CurrentGameCover" Stretch="UniformToFill" ClipToBounds="True"/>
                             </Border>
                             
-                            <!-- Game Info -->
                             <StackPanel Grid.Column="2" VerticalAlignment="Top">
                                 <TextBlock Text="NOW PLAYING" FontSize="10" FontWeight="Bold" 
                                            Foreground="#888888" Margin="0,0,0,10"/>
@@ -59,7 +55,6 @@
                                 <TextBlock x:Name="CurrentGameInfo" FontSize="13" 
                                            Foreground="#AAAAAA" Margin="0,0,0,12" TextWrapping="Wrap"/>
                                 
-                                <!-- Achievements Section (hidden when no data) -->
                                 <StackPanel x:Name="AchievementsPanel" Visibility="Collapsed" Margin="0,0,0,12">
                                     <TextBlock x:Name="AchievementsProgress" FontSize="12" 
                                                Foreground="#AAAAAA" Margin="0,0,0,6"/>
@@ -67,7 +62,6 @@
                                     <StackPanel x:Name="LockedAchievementsList"/>
                                 </StackPanel>
                                 
-                                <!-- Action Buttons -->
                                 <StackPanel Orientation="Horizontal">
                                     <Button x:Name="SwitchBtn" Content="Return to Playnite" 
                                             Margin="0,0,12,0" Padding="16,8" MinWidth="150"
@@ -138,11 +132,9 @@
                                 </StackPanel>
                             </StackPanel>
                             
-                             <!-- Audio Device Selector (Top-Right Corner) -->
                              <StackPanel Grid.Column="3" Grid.Row="0" 
                                          VerticalAlignment="Top" HorizontalAlignment="Right" 
                                          Margin="12,0,0,0">
-                                <!-- Audio Controls Row: Combo + Mute Button -->
                                 <Grid x:Name="AudioControlsRow" Visibility="Collapsed">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
@@ -299,7 +291,6 @@
                                         </Button.Style>
                                     </Button>
                                 </Grid>
-                                <!-- Volume Slider (full width, below) -->
                                 <Border x:Name="VolumeControls"
                                         Background="#2A2A2A"
                                         BorderBrush="#3A3A3A"
@@ -408,8 +399,6 @@
                             </StackPanel>
                         </Grid>
                     </Border>
-                    
-                    <!-- Running Apps Section (shown when other apps detected) -->
                     <Border x:Name="RunningAppsSection" Background="#252525" CornerRadius="8" 
                             Padding="16" Margin="0,0,0,20" Visibility="Collapsed"
                             BorderThickness="2" BorderBrush="Transparent" Focusable="True">
@@ -458,26 +447,22 @@
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             
-                                            <!-- Small icon/thumbnail -->
                                             <Border Grid.Column="0" Background="#1A1A1A" 
                                                     CornerRadius="4" Width="32" Height="32" 
                                                     Margin="0,0,12,0">
                                                 <Grid>
                                                     <Image Source="{Binding ImagePath}" 
                                                            Stretch="UniformToFill" ClipToBounds="True"/>
-                                                    <!-- Fallback icon -->
                                                     <TextBlock x:Name="NoAppImage" Text="🎮" FontSize="16" 
                                                                HorizontalAlignment="Center" VerticalAlignment="Center"
                                                                Foreground="#555555" Visibility="Collapsed"/>
                                                 </Grid>
                                             </Border>
                                             
-                                            <!-- App title -->
                                             <TextBlock Grid.Column="1" Text="{Binding Title}" 
                                                        FontSize="13" Foreground="#EEEEEE" FontWeight="Medium"
                                                        VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
                                             
-                                            <!-- Switch button -->
                                             <Button Grid.Column="2" Content="↗ Switch" Width="90" 
                                                     Height="30" VerticalAlignment="Center" 
                                                     CommandParameter="{Binding}"
@@ -514,7 +499,6 @@
                                             </Button>
                                         </Grid>
                                         <DataTemplate.Triggers>
-                                            <!-- Show fallback icon if ImagePath is null -->
                                             <DataTrigger Binding="{Binding ImagePath}" Value="{x:Null}">
                                                 <Setter TargetName="NoAppImage" Property="Visibility" Value="Visible"/>
                                             </DataTrigger>
@@ -525,14 +509,23 @@
                         </StackPanel>
                     </Border>
                     
-                    <!-- Recent Games Section -->
+                    <Border x:Name="ShortcutsSection" Background="#252525" CornerRadius="8" 
+                            Padding="16" Margin="0,0,0,20" Visibility="Collapsed"
+                            BorderThickness="2" BorderBrush="Transparent" Focusable="True">
+                        <StackPanel>
+                            <TextBlock Text="QUICK ACTIONS" FontSize="10" FontWeight="Bold" 
+                                       Foreground="#888888" Margin="0,0,0,10"/>
+                            
+                            <StackPanel x:Name="ShortcutsPanel" Orientation="Horizontal" />
+                        </StackPanel>
+                    </Border>
+                    
                     <Border x:Name="RecentGamesSection" Background="#252525" CornerRadius="8"
                             Padding="16" BorderThickness="2" BorderBrush="Transparent" Focusable="True">
                         <StackPanel>
                             <TextBlock Text="RECENT GAMES" FontSize="10" FontWeight="Bold" 
                                        Foreground="#888888" Margin="0,0,0,10"/>
                         
-                            <!-- Empty State (shown when no items) -->
                             <Border x:Name="EmptyState" Background="#1A1A1A" CornerRadius="6" 
                                     Padding="40,32" Visibility="Collapsed">
                             <StackPanel HorizontalAlignment="Center">
@@ -547,7 +540,6 @@
                             </StackPanel>
                         </Border>
                         
-                        <!-- Recent Games List -->
                         <ListBox x:Name="RecentList" Background="Transparent" 
                                  BorderThickness="0" HorizontalContentAlignment="Stretch" 
                                  Focusable="False"
@@ -590,21 +582,18 @@
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
                                         
-                                        <!-- Small thumbnail -->
                                         <Border Grid.Column="0" Background="#1A1A1A" 
                                                 CornerRadius="4" Width="50" Height="68" 
                                                 Margin="0,0,14,0">
                                             <Grid>
                                                 <Image Source="{Binding ImagePath}" 
                                                        Stretch="UniformToFill" ClipToBounds="True"/>
-                                                <!-- Fallback text if no image -->
                                                 <TextBlock x:Name="NoImageText" Text="🎮" FontSize="24" 
                                                            HorizontalAlignment="Center" VerticalAlignment="Center"
                                                            Foreground="#555555" Visibility="Collapsed"/>
                                             </Grid>
                                         </Border>
                                         
-                                        <!-- Game info -->
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                             <TextBlock Text="{Binding Title}" FontSize="14" 
                                                        Foreground="#EEEEEE" FontWeight="Medium" 
@@ -613,7 +602,6 @@
                                                        FontSize="11" Foreground="#888888"/>
                                         </StackPanel>
                                         
-                                        <!-- Play button -->
                                         <Button Grid.Column="2" Content="▶ Play" Width="90" 
                                                 Height="34" VerticalAlignment="Center" 
                                                 CommandParameter="{Binding}"
@@ -650,7 +638,6 @@
                                         </Button>
                                     </Grid>
                                     <DataTemplate.Triggers>
-                                        <!-- Show fallback icon if ImagePath is null -->
                                         <DataTrigger Binding="{Binding ImagePath}" Value="{x:Null}">
                                             <Setter TargetName="NoImageText" Property="Visibility" Value="Visible"/>
                                         </DataTrigger>

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -737,8 +737,6 @@ public partial class OverlayWindow : Window
     }
     #endregion
 
-    #region Navigation Commands
-    #endregion
 
     #region Navigation Commands
 
@@ -1037,7 +1035,7 @@ public partial class OverlayWindow : Window
     {
         if (!isInsideSection)
         {
-                    EnterSection(navigationTarget);
+            EnterSection(navigationTarget);
         }
         else
         {

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -690,7 +690,14 @@ public partial class OverlayWindow : Window
                     break;
 
                 case NavigationTarget.ShortcutItem:
-                    ExitToSectionLevel();
+                    if (shortcutsSelectedIndex <= 0)
+                    {
+                        ExitToSectionLevel();
+                    }
+                    else
+                    {
+                        FocusShortcutButton(shortcutsSelectedIndex - 1);
+                    }
                     break;
 
                 case NavigationTarget.RecentGameItem:
@@ -779,7 +786,18 @@ public partial class OverlayWindow : Window
                     break;
 
                 case NavigationTarget.ShortcutItem:
-                    ExitToSectionLevel();
+                    if (ShortcutsPanel == null || ShortcutsPanel.Children.Count == 0)
+                    {
+                        ExitToSectionLevel();
+                    }
+                    else if (shortcutsSelectedIndex >= ShortcutsPanel.Children.Count - 1)
+                    {
+                        ExitToSectionLevel();
+                    }
+                    else
+                    {
+                        FocusShortcutButton(shortcutsSelectedIndex + 1);
+                    }
                     break;
 
                 case NavigationTarget.RecentGameItem:

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -1221,10 +1221,21 @@ public partial class OverlayWindow : Window
             contentPresenterFactory.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
             borderFactory.AppendChild(contentPresenterFactory);
             template.VisualTree = borderFactory;
+            
+            // Add triggers to ControlTemplate (not Style) so we can use TargetName
+            var mouseOverTrigger = new Trigger { Property = Button.IsMouseOverProperty, Value = true };
+            mouseOverTrigger.Setters.Add(new Setter { TargetName = "ButtonBorder", Property = Border.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x4A, 0x4A, 0x4A)) });
+            template.Triggers.Add(mouseOverTrigger);
+            
+            var pressedTrigger = new Trigger { Property = Button.IsPressedProperty, Value = true };
+            pressedTrigger.Setters.Add(new Setter { TargetName = "ButtonBorder", Property = Border.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x2A)) });
+            template.Triggers.Add(pressedTrigger);
+            
+            var focusTrigger = new Trigger { Property = Button.IsKeyboardFocusedProperty, Value = true };
+            focusTrigger.Setters.Add(new Setter { TargetName = "ButtonBorder", Property = Border.BorderBrushProperty, Value = new SolidColorBrush(Colors.White) });
+            template.Triggers.Add(focusTrigger);
+            
             style.Setters.Add(new Setter(Button.TemplateProperty, template));
-            style.Triggers.Add(new Trigger { Property = Button.IsMouseOverProperty, Value = true, Setters = { new Setter { Property = Button.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x4A, 0x4A, 0x4A)) } } });
-            style.Triggers.Add(new Trigger { Property = Button.IsPressedProperty, Value = true, Setters = { new Setter { Property = Button.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x2A)) } } });
-            style.Triggers.Add(new Trigger { Property = Button.IsKeyboardFocusedProperty, Value = true, Setters = { new Setter { Property = Button.BorderBrushProperty, Value = new SolidColorBrush(Colors.White) } } });
             button.Style = style;
             button.Click += (_, __) =>
             {

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -68,7 +68,7 @@ public partial class OverlayWindow : Window
         this.runningApps = new List<RunningApp>(runningApps);
         this.shortcuts = shortcuts != null ? new List<Models.OverlayShortcut>(shortcuts) : new List<Models.OverlayShortcut>();
 
-            timeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        timeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         timeTimer.Tick += TimeTimer_Tick;
         timeTimer.Start();
 
@@ -174,8 +174,9 @@ public partial class OverlayWindow : Window
         
         Backdrop.MouseLeftButtonDown += (_, __) => this.Close();
         PreviewKeyDown += OnPreviewKeyDown;
+        Closing += OnClosingWithFade;
         
-        Loaded += async (_, __) =>
+        Loaded += (_, __) =>
         {
             Activate(); Focus(); Keyboard.Focus(this);
             

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -1260,7 +1260,7 @@ public partial class OverlayWindow : Window
             if (shortcut.ActionType == ShortcutActionType.SendInput)
             {
                 logger.Info($"ExecuteShortcutAction: Sending hotkey '{shortcut.Hotkey}'");
-                NativeInput.SendHotkey(shortcut.Hotkey);
+                System.Threading.Tasks.Task.Run(() => NativeInput.SendHotkey(shortcut.Hotkey));
                 return;
             }
 
@@ -1269,7 +1269,8 @@ public partial class OverlayWindow : Window
                 var processStartInfo = new System.Diagnostics.ProcessStartInfo
                 {
                     FileName = shortcut.Command,
-                    Arguments = shortcut.Arguments ?? string.Empty
+                    Arguments = shortcut.Arguments ?? string.Empty,
+                    UseShellExecute = true
                 };
                 var commandDirectory = Path.GetDirectoryName(shortcut.Command);
                 if (!string.IsNullOrEmpty(commandDirectory))
@@ -1281,7 +1282,7 @@ public partial class OverlayWindow : Window
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error running shortcut action: {ex.Message}");
+            logger.Error(ex, $"Failed to execute shortcut action '{shortcut.Label}'");
         }
     }
 

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -1222,9 +1222,9 @@ public partial class OverlayWindow : Window
             borderFactory.AppendChild(contentPresenterFactory);
             template.VisualTree = borderFactory;
             style.Setters.Add(new Setter(Button.TemplateProperty, template));
-            style.Triggers.Add(new Trigger { Property = Button.IsMouseOverProperty, Value = true, Setters = { new Setter { Property = Border.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x4A, 0x4A, 0x4A)) } } });
-            style.Triggers.Add(new Trigger { Property = Button.IsPressedProperty, Value = true, Setters = { new Setter { Property = Border.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x2A)) } } });
-            style.Triggers.Add(new Trigger { Property = Button.IsKeyboardFocusedProperty, Value = true, Setters = { new Setter { Property = Border.BorderBrushProperty, Value = new SolidColorBrush(Colors.White) } } });
+            style.Triggers.Add(new Trigger { Property = Button.IsMouseOverProperty, Value = true, Setters = { new Setter { Property = Button.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x4A, 0x4A, 0x4A)) } } });
+            style.Triggers.Add(new Trigger { Property = Button.IsPressedProperty, Value = true, Setters = { new Setter { Property = Button.BackgroundProperty, Value = new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x2A)) } } });
+            style.Triggers.Add(new Trigger { Property = Button.IsKeyboardFocusedProperty, Value = true, Setters = { new Setter { Property = Button.BorderBrushProperty, Value = new SolidColorBrush(Colors.White) } } });
             button.Style = style;
             button.Click += (_, __) =>
             {

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -555,12 +555,24 @@ public partial class OverlayWindow : Window
         navigationTarget = NavigationTarget.ShortcutItem;
         shortcutsSelectedIndex = index;
 
-        var button = ShortcutsPanel.Children[index] as Button;
-        if (button != null)
+        // Use async fallback pattern like FocusRunningAppItem for robustness
+        if (!TryFocusShortcutButton())
         {
-            button.Focus();
-            ShortcutsSection.BringIntoView();
+            Dispatcher.BeginInvoke(() => TryFocusShortcutButton(), DispatcherPriority.Loaded);
         }
+    }
+
+    private bool TryFocusShortcutButton()
+    {
+        if (ShortcutsPanel == null || shortcutsSelectedIndex < 0 || shortcutsSelectedIndex >= ShortcutsPanel.Children.Count)
+            return false;
+
+        var button = ShortcutsPanel.Children[shortcutsSelectedIndex] as Button;
+        if (button == null) return false;
+
+        button.Focus();
+        ShortcutsSection.BringIntoView();
+        return true;
     }
 
     private void FocusRunningAppItem(int index)
@@ -690,14 +702,8 @@ public partial class OverlayWindow : Window
                     break;
 
                 case NavigationTarget.ShortcutItem:
-                    if (shortcutsSelectedIndex <= 0)
-                    {
-                        ExitToSectionLevel();
-                    }
-                    else
-                    {
-                        FocusShortcutButton(shortcutsSelectedIndex - 1);
-                    }
+                    // Shortcuts are horizontal - Up/Down should exit to section level, not change index
+                    ExitToSectionLevel();
                     break;
 
                 case NavigationTarget.RecentGameItem:
@@ -786,18 +792,8 @@ public partial class OverlayWindow : Window
                     break;
 
                 case NavigationTarget.ShortcutItem:
-                    if (ShortcutsPanel == null || ShortcutsPanel.Children.Count == 0)
-                    {
-                        ExitToSectionLevel();
-                    }
-                    else if (shortcutsSelectedIndex >= ShortcutsPanel.Children.Count - 1)
-                    {
-                        ExitToSectionLevel();
-                    }
-                    else
-                    {
-                        FocusShortcutButton(shortcutsSelectedIndex + 1);
-                    }
+                    // Shortcuts are horizontal - Up/Down should exit to section level, not change index
+                    ExitToSectionLevel();
                     break;
 
                 case NavigationTarget.RecentGameItem:

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using Playnite.SDK;
 using PlayniteOverlay.Models;
 using PlayniteOverlay.Services;
 using PlayniteOverlay.Interop;
@@ -18,6 +19,8 @@ namespace PlayniteOverlay;
 
 public partial class OverlayWindow : Window
 {
+    private static readonly ILogger logger = LogManager.GetLogger();
+
     [DllImport("user32.dll")]
     private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
@@ -1257,8 +1260,11 @@ public partial class OverlayWindow : Window
     {
         try
         {
-            if (shortcut.ActionType == ShortcutActionType.SendInput)
+        if (shortcut.ActionType == ShortcutActionType.SendInput)
             {
+                logger.Info($"ExecuteShortcutAction: Sending hotkey '{shortcut.Hotkey}'");
+                // Small delay to let focus return to target window after overlay closes
+                System.Threading.Thread.Sleep(100);
                 NativeInput.SendHotkey(shortcut.Hotkey);
                 return;
             }

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -575,6 +575,20 @@ public partial class OverlayWindow : Window
         return true;
     }
 
+    private int GetShortcutsPerRow()
+    {
+        if (ShortcutsPanel == null || ShortcutsPanel.Children.Count == 0)
+            return 1;
+
+        var panelWidth = ShortcutsPanel.ActualWidth;
+        if (panelWidth <= 0)
+            return 1;
+
+        // Button width: MinWidth (110) + Margin (8) = 118px
+        const double buttonWidth = 118;
+        return Math.Max(1, (int)(panelWidth / buttonWidth));
+    }
+
     private void FocusRunningAppItem(int index)
     {
         if (!Dispatcher.CheckAccess())
@@ -702,8 +716,19 @@ public partial class OverlayWindow : Window
                     break;
 
                 case NavigationTarget.ShortcutItem:
-                    // Shortcuts are horizontal - Up/Down should exit to section level, not change index
-                    ExitToSectionLevel();
+                    {
+                        // Navigate up in WrapPanel grid
+                        int perRow = GetShortcutsPerRow();
+                        int newIndex = shortcutsSelectedIndex - perRow;
+                        if (newIndex < 0)
+                        {
+                            ExitToSectionLevel();
+                        }
+                        else
+                        {
+                            FocusShortcutButton(newIndex);
+                        }
+                    }
                     break;
 
                 case NavigationTarget.RecentGameItem:
@@ -792,8 +817,19 @@ public partial class OverlayWindow : Window
                     break;
 
                 case NavigationTarget.ShortcutItem:
-                    // Shortcuts are horizontal - Up/Down should exit to section level, not change index
-                    ExitToSectionLevel();
+                    {
+                        // Navigate down in WrapPanel grid
+                        int perRow = GetShortcutsPerRow();
+                        int newIndex = shortcutsSelectedIndex + perRow;
+                        if (newIndex >= ShortcutsPanel.Children.Count)
+                        {
+                            ExitToSectionLevel();
+                        }
+                        else
+                        {
+                            FocusShortcutButton(newIndex);
+                        }
+                    }
                     break;
 
                 case NavigationTarget.RecentGameItem:
@@ -1194,7 +1230,7 @@ public partial class OverlayWindow : Window
             var button = new Button
             {
                 Content = shortcut.Label,
-                Margin = new Thickness(0, 0, 8, 0),
+                Margin = new Thickness(0, 0, 8, 8),
                 Padding = new Thickness(16, 8, 16, 8),
                 MinWidth = 110,
                 Background = new SolidColorBrush(Color.FromRgb(0x3A, 0x3A, 0x3A)),

--- a/src/OverlayPlugin/Services/OverlayService.cs
+++ b/src/OverlayPlugin/Services/OverlayService.cs
@@ -14,7 +14,6 @@ internal sealed class OverlayService
     private readonly object windowLock = new object();
     private readonly InputListener inputListener;
     private OverlayWindow? window;
-
     public OverlayService(InputListener inputListener)
     {
         this.inputListener = inputListener ?? throw new ArgumentNullException(nameof(inputListener));
@@ -25,7 +24,7 @@ internal sealed class OverlayService
         get { lock (windowLock) return window != null; }
     }
 
-    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string, Action<bool>>? onAudioDeviceChanged = null, GameVolumeService? gameVolumeService = null, int? currentGameProcessId = null, GameSwitcher? gameSwitcher = null)
+    public void Show(Action onSwitch, Action onExit, OverlayItem? currentGame, IEnumerable<RunningApp> runningApps, IEnumerable<OverlayItem> recentGames, IEnumerable<AudioDevice>? audioDevices = null, Action<string, Action<bool>>? onAudioDeviceChanged = null, GameVolumeService? gameVolumeService = null, int? currentGameProcessId = null, GameSwitcher? gameSwitcher = null, OverlaySettings? settings = null, IEnumerable<Models.OverlayShortcut>? shortcuts = null)
     {
         lock (windowLock)
         {
@@ -36,7 +35,7 @@ internal sealed class OverlayService
 
             Application.Current?.Dispatcher.Invoke(() =>
             {
-                window = new OverlayWindow(onSwitch, onExit, currentGame, runningApps, recentGames, audioDevices, onAudioDeviceChanged, gameVolumeService, currentGameProcessId, gameSwitcher);
+                window = new OverlayWindow(onSwitch, onExit, currentGame, runningApps, recentGames, audioDevices, onAudioDeviceChanged, gameVolumeService, currentGameProcessId, gameSwitcher, shortcuts: shortcuts);
 
                 window.Loaded += (_, _) =>
                 {
@@ -56,7 +55,6 @@ internal sealed class OverlayService
                 {
                     // Disconnect controller navigation
                     inputListener.SetOverlayWindow(null);
-
                     lock (windowLock)
                     {
                         window = null;

--- a/src/OverlayPlugin/Settings/OverlaySettings.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettings.cs
@@ -125,4 +125,19 @@ public class OverlaySettings : MVVM.ObservableObject
         get => maxLockedAchievements;
         set => SetProperty(ref maxLockedAchievements, value);
     }
+
+    private System.Collections.ObjectModel.ObservableCollection<Models.OverlayShortcut> shortcuts = new System.Collections.ObjectModel.ObservableCollection<Models.OverlayShortcut>();
+    /// <summary>
+    /// User-defined keyboard shortcuts that can be triggered from the overlay.
+    /// </summary>
+    public System.Collections.ObjectModel.ObservableCollection<Models.OverlayShortcut> Shortcuts
+    {
+        get => shortcuts;
+        set => SetProperty(ref shortcuts, value);
+    }
+
+    /// <summary>
+    /// Maximum number of shortcuts allowed.
+    /// </summary>
+    public const int MaxShortcuts = 10;
 }

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
@@ -3,8 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:models="clr-namespace:PlayniteOverlay.Models"
+             xmlns:converters="clr-namespace:PlayniteOverlay.Converters"
              mc:Ignorable="d"
              d:DesignWidth="540" d:DesignHeight="320">
+    <UserControl.Resources>
+        <converters:EnumToVisibilityConverter x:Key="EnumToVisibilityConverter" />
+    </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <StackPanel Margin="10" Orientation="Vertical" >
             <TextBlock Text="Overlay Settings" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
@@ -117,6 +122,114 @@
                     <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
                                Foreground="Orange"
                                Text="Note: This only works for games running in windowed mode. For games in true exclusive fullscreen, you'll need to change the game's display settings to Windowed or Borderless."/>
+                </StackPanel>
+            </GroupBox>
+            <GroupBox Header="Shortcuts">
+                <StackPanel Margin="10">
+                    <TextBlock Text="Configure custom shortcut buttons that appear in the overlay." TextWrapping="Wrap" Margin="0,0,0,10"/>
+                    <ScrollViewer MaxHeight="200" VerticalScrollBarVisibility="Auto">
+                        <ItemsControl x:Name="ShortcutsList" ItemsSource="{Binding Settings.Shortcuts}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Expander x:Name="ShortcutExpander" Margin="0,2,0,2"
+                                              Expanded="ShortcutExpander_Expanded">
+                                        <Expander.Header>
+                                            <Grid Margin="4,2">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="120"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0" Text="{Binding Label}" FontWeight="Bold" Foreground="{DynamicResource TextBrush}" TextTrimming="None" TextWrapping="Wrap"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding Command}" Foreground="{DynamicResource TextBrush}" TextTrimming="None" TextWrapping="Wrap" Margin="8,0,0,0"/>
+                                            </Grid>
+                                        </Expander.Header>
+                                        <Grid Margin="5,5,5,5">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="70"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Label:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                            <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
+                                                     Text="{Binding Label, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,0,0,6"
+                                                     Foreground="{DynamicResource TextBrush}"/>
+
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Action:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"/>
+                                            <ComboBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,6"
+                                                      SelectedValuePath="Tag"
+                                                      SelectedValue="{Binding ActionType}"
+                                                      Foreground="{DynamicResource TextBrush}">
+                                                <ComboBoxItem Content="CommandLine" Tag="{x:Static models:ShortcutActionType.CommandLine}"/>
+                                                <ComboBoxItem Content="SendInput" Tag="{x:Static models:ShortcutActionType.SendInput}"/>
+                                            </ComboBox>
+
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Command:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"
+                                                       Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.CommandLine}}"/>
+                                            <TextBox Grid.Row="2" Grid.Column="1"
+                                                     Text="{Binding Command, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,0,0,6"
+                                                     Foreground="{DynamicResource TextBrush}"
+                                                     Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.CommandLine}}"/>
+                                            <Button Grid.Row="2" Grid.Column="2" Content="Browse"
+                                                    MinWidth="70" Margin="5,0,0,6"
+                                                    Click="ShortcutBrowse_Click"
+                                                    Tag="{Binding}"
+                                                    Foreground="{DynamicResource TextBrush}"
+                                                    Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.CommandLine}}"/>
+
+                                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Arguments:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"
+                                                       Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.CommandLine}}"/>
+                                            <TextBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2"
+                                                     Text="{Binding Arguments, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,0,0,6"
+                                                     Foreground="{DynamicResource TextBrush}"
+                                                     Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.CommandLine}}"/>
+
+                                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Hotkey:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"
+                                                       Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.SendInput}}"/>
+                                            <Grid Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,6"
+                                                  Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.SendInput}}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBox Grid.Column="0"
+                                                         Text="{Binding Hotkey}"
+                                                         IsReadOnly="True"
+                                                         PreviewKeyDown="ShortcutHotkey_PreviewKeyDown"
+                                                         Tag="{Binding}"
+                                                         Foreground="{DynamicResource TextBrush}"/>
+                                                <Button Grid.Column="1" Content="Clear" Margin="6,0,0,0"
+                                                        Click="ShortcutHotkey_Clear_Click"
+                                                        Tag="{Binding}"
+                                                        Foreground="{DynamicResource TextBrush}"/>
+                                            </Grid>
+
+                                            <Button Grid.Row="5" Grid.Column="2" Content="Delete"
+                                                    MinWidth="70" HorizontalAlignment="Right"
+                                                    Click="ShortcutDelete_Click"
+                                                    Tag="{Binding}"
+                                                    Foreground="{DynamicResource TextBrush}"/>
+                                        </Grid>
+                                    </Expander>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                    <Button x:Name="AddShortcutBtn" Content="+ Add Shortcut"
+                            HorizontalAlignment="Left" Margin="0,10,0,0"
+                            Click="AddShortcutBtn_Click"/>
+                    <TextBlock Text="Maximum 10 shortcuts" FontSize="10" Foreground="Gray" Margin="0,5,0,0"/>
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml.cs
@@ -122,7 +122,7 @@ public partial class OverlaySettingsView : UserControl
 
     private void ShortcutBrowse_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is Button button && button.Tag is OverlayShortcut shortcut)
+        if (sender is Button { Tag: OverlayShortcut shortcut })
         {
             var dialog = new Microsoft.Win32.OpenFileDialog
             {
@@ -196,7 +196,7 @@ public partial class OverlaySettingsView : UserControl
 
     private void ShortcutHotkey_Clear_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is Button button && button.Tag is OverlayShortcut shortcut)
+        if (sender is Button { Tag: OverlayShortcut shortcut })
         {
             shortcut.Hotkey = string.Empty;
         }

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using PlayniteOverlay.Models;
 
 namespace PlayniteOverlay;
 
@@ -8,13 +11,26 @@ public partial class OverlaySettingsView : UserControl
     public OverlaySettingsView()
     {
         InitializeComponent();
+        Loaded += OverlaySettingsView_Loaded;
+    }
+
+    private void OverlaySettingsView_Loaded(object sender, RoutedEventArgs e)
+    {
+        UpdateAddButtonState();
     }
 
     private OverlaySettings? Model => (DataContext as OverlaySettingsViewModel)?.Settings;
 
+    private void UpdateAddButtonState()
+    {
+        if (Model != null && AddShortcutBtn != null)
+        {
+            AddShortcutBtn.IsEnabled = Model.Shortcuts.Count < OverlaySettings.MaxShortcuts;
+        }
+    }
+
     private static string BuildGestureFromKeyEvent(KeyEventArgs e)
     {
-        // Ignore modifier-only presses
         if (e.Key is Key.LeftCtrl or Key.RightCtrl or Key.LeftShift or Key.RightShift or Key.LeftAlt or Key.RightAlt or Key.LWin or Key.RWin)
         {
             return string.Empty;
@@ -53,12 +69,136 @@ public partial class OverlaySettingsView : UserControl
         }
     }
 
-    private void Hotkey_Clear_Click(object sender, System.Windows.RoutedEventArgs e)
+    private void Hotkey_Clear_Click(object sender, RoutedEventArgs e)
     {
         if (Model != null)
         {
             Model.CustomHotkey = string.Empty;
             Model.EnableCustomHotkey = false;
+        }
+    }
+
+
+    private void AddShortcutBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (Model == null || Model.Shortcuts.Count >= OverlaySettings.MaxShortcuts)
+        {
+            return;
+        }
+
+        var newShortcut = new OverlayShortcut
+        {
+            Label = "New Shortcut",
+            Command = string.Empty,
+            Arguments = string.Empty,
+            ActionType = ShortcutActionType.CommandLine,
+            Hotkey = string.Empty
+        };
+
+        Model.Shortcuts.Add(newShortcut);
+        UpdateAddButtonState();
+
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            if (ShortcutsList.ItemContainerGenerator.ContainerFromItem(newShortcut) is ContentPresenter presenter)
+            {
+                var expander = FindVisualChild<Expander>(presenter);
+                if (expander != null)
+                {
+                    expander.IsExpanded = true;
+                }
+            }
+        }), System.Windows.Threading.DispatcherPriority.Loaded);
+    }
+
+    private void ShortcutDelete_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is OverlayShortcut shortcut && Model != null)
+        {
+            Model.Shortcuts.Remove(shortcut);
+            UpdateAddButtonState();
+        }
+    }
+
+    private void ShortcutBrowse_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is OverlayShortcut shortcut)
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = "Executable files (*.exe)|*.exe|All files (*.*)|*.*",
+                Title = "Select Command"
+            };
+
+            if (dialog.ShowDialog() == true)
+            {
+                shortcut.Command = dialog.FileName;
+            }
+        }
+    }
+
+    private void ShortcutExpander_Expanded(object sender, RoutedEventArgs e)
+    {
+        if (sender is Expander expander)
+        {
+            foreach (var item in ShortcutsList.Items)
+            {
+                if (ShortcutsList.ItemContainerGenerator.ContainerFromItem(item) is ContentPresenter presenter)
+                {
+                    var otherExpander = FindVisualChild<Expander>(presenter);
+                    if (otherExpander != null && otherExpander != expander)
+                    {
+                        otherExpander.IsExpanded = false;
+                    }
+                }
+            }
+        }
+    }
+
+    private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+    {
+        for (int i = 0; i < System.Windows.Media.VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(parent, i);
+            if (child is T result)
+            {
+                return result;
+            }
+            var descendant = FindVisualChild<T>(child);
+            if (descendant != null)
+            {
+                return descendant;
+            }
+        }
+        return null;
+    }
+
+    private void ShortcutHotkey_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        e.Handled = true;
+        if (sender is not TextBox box || box.Tag is not OverlayShortcut shortcut)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Escape)
+        {
+            shortcut.Hotkey = string.Empty;
+            return;
+        }
+
+        var gesture = BuildGestureFromKeyEvent(e);
+        if (!string.IsNullOrWhiteSpace(gesture))
+        {
+            shortcut.Hotkey = gesture;
+        }
+    }
+
+    private void ShortcutHotkey_Clear_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is OverlayShortcut shortcut)
+        {
+            shortcut.Hotkey = string.Empty;
         }
     }
 }


### PR DESCRIPTION
## Summary
Replace capture integrations with enhanced custom shortcuts that can launch command lines or send hotkeys, plus settings UI improvements.

## Features
- **Shortcut action types**: CommandLine or SendInput (hotkey simulation)
- **Settings UI** for action type selection and hotkey capture
- **Overlay shortcuts** execute the selected action type
- **Theme-consistent** shortcut editor styling
- **Logging** for SendInput failures

## Removals
- OBS/ShareX capture services and CaptureManager
- Capture settings UI and capture buttons in overlay

## Technical Details
- `OverlayShortcut` now includes `ActionType` and `Hotkey`
- `NativeInput` sends hotkeys via Win32 `SendInput`
- Settings view shows/hides fields based on `ActionType`

## Testing
- Build: `dotnet build src/OverlayPlugin/OverlayPlugin.csproj`
- Tests: `dotnet test tests/OverlayPlugin.Tests/OverlayPlugin.Tests.csproj`
  - Fails locally in this environment due to missing net472 test host/mono