### PR TITLE
feat(shortcuts): add media key action type for shortcuts

### DIFF
--- a/src/OverlayPlugin/Interop/NativeInput.cs
+++ b/src/OverlayPlugin/Interop/NativeInput.cs
@@ -20,6 +20,15 @@ internal static class NativeInput
     private const byte VK_MENU = 0x12;    // Alt
     private const byte VK_LWIN = 0x5B;
 
+    // Virtual key codes for media keys
+    private const ushort VK_VOLUME_MUTE = 0xAD;
+    private const ushort VK_VOLUME_DOWN = 0xAE;
+    private const ushort VK_VOLUME_UP = 0xAF;
+    private const ushort VK_MEDIA_NEXT_TRACK = 0xB0;
+    private const ushort VK_MEDIA_PREV_TRACK = 0xB1;
+    private const ushort VK_MEDIA_STOP = 0xB2;
+    private const ushort VK_MEDIA_PLAY_PAUSE = 0xB3;
+
     private const int ModifierDelayMs = 10;      // Delay after modifier press/release
     private const int KeyHoldDelayMs = 50;       // How long to hold main key (must be > 25ms for OBS polling)
 
@@ -48,6 +57,146 @@ internal static class NativeInput
         logger.Info($"SendHotkey: gesture='{gesture}', vk=0x{vk:X2}");
 
         SendHotkeyWithDelays(modifiers, vk);
+    }
+
+    /// <summary>
+    /// Sends a media key by name.
+    /// </summary>
+    /// <param name="mediaKey">Media key name: PlayPause, Stop, NextTrack, PreviousTrack, VolumeUp, VolumeDown, Mute</param>
+    public static void SendMediaKey(string? mediaKey)
+    {
+        if (string.IsNullOrWhiteSpace(mediaKey))
+        {
+            logger.Warn("SendMediaKey called with empty key.");
+            return;
+        }
+
+        var vk = mediaKey!.ToLowerInvariant() switch
+        {
+            "playpause" => VK_MEDIA_PLAY_PAUSE,
+            "stop" => VK_MEDIA_STOP,
+            "nexttrack" => VK_MEDIA_NEXT_TRACK,
+            "previoustrack" => VK_MEDIA_PREV_TRACK,
+            "volumeup" => VK_VOLUME_UP,
+            "volumedown" => VK_VOLUME_DOWN,
+            "mute" => VK_VOLUME_MUTE,
+            _ => (ushort?)null
+        };
+
+        if (vk == null)
+        {
+            logger.Warn($"SendMediaKey: Unknown media key '{mediaKey}'.");
+            return;
+        }
+
+        logger.Info($"SendMediaKey: key='{mediaKey}', vk=0x{vk:X2}");
+        SendKeyPress(vk.Value);
+    }
+
+    /// <summary>
+    /// Sends a single key press (down + up) with no modifiers.
+    /// </summary>
+    private static void SendKeyPress(ushort vk)
+    {
+        try
+        {
+            if (IntPtr.Size == 8)
+            {
+                SendKeyPress64(vk);
+            }
+            else
+            {
+                SendKeyPress32(vk);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, $"SendKeyPress failed: {ex.Message}");
+            SendKeyPressViaKeybdEvent(vk);
+        }
+    }
+
+    private static void SendKeyPress32(ushort vk)
+    {
+        var inputs = new List<INPUT32>();
+        int inputSize = Marshal.SizeOf(typeof(INPUT32));
+        const int expectedInputSize = 28;
+
+        if (inputSize != expectedInputSize)
+        {
+            logger.Warn($"SendKeyPress32: INPUT size mismatch. Falling back to keybd_event.");
+            SendKeyPressViaKeybdEvent(vk);
+            return;
+        }
+
+        // Press key
+        inputs.Add(CreateKeyInput32(vk, keyUp: false));
+        uint sentDown = SendInput32(1, inputs.ToArray(), inputSize);
+        if (sentDown == 0)
+        {
+            logger.Warn($"SendKeyPress32: SendInput failed for key down.");
+            SendKeyPressViaKeybdEvent(vk);
+            return;
+        }
+        Thread.Sleep(KeyHoldDelayMs);
+
+        // Release key
+        inputs.Clear();
+        inputs.Add(CreateKeyInput32(vk, keyUp: true));
+        uint sentUp = SendInput32(1, inputs.ToArray(), inputSize);
+        if (sentUp == 0)
+        {
+            logger.Warn($"SendKeyPress32: SendInput failed for key up.");
+        }
+    }
+
+    private static void SendKeyPress64(ushort vk)
+    {
+        var inputs = new List<INPUT64>();
+        int inputSize = Marshal.SizeOf(typeof(INPUT64));
+        const int expectedInputSize = 40;
+
+        if (inputSize != expectedInputSize)
+        {
+            logger.Warn($"SendKeyPress64: INPUT size mismatch. Falling back to keybd_event.");
+            SendKeyPressViaKeybdEvent(vk);
+            return;
+        }
+
+        // Press key
+        inputs.Add(CreateKeyInput64(vk, keyUp: false));
+        uint sentDown = SendInput64(1, inputs.ToArray(), inputSize);
+        if (sentDown == 0)
+        {
+            logger.Warn($"SendKeyPress64: SendInput failed for key down.");
+            SendKeyPressViaKeybdEvent(vk);
+            return;
+        }
+        Thread.Sleep(KeyHoldDelayMs);
+
+        // Release key
+        inputs.Clear();
+        inputs.Add(CreateKeyInput64(vk, keyUp: true));
+        uint sentUp = SendInput64(1, inputs.ToArray(), inputSize);
+        if (sentUp == 0)
+        {
+            logger.Warn($"SendKeyPress64: SendInput failed for key up.");
+        }
+    }
+
+    private static void SendKeyPressViaKeybdEvent(ushort vk)
+    {
+        try
+        {
+            keybd_event((byte)vk, 0, 0, 0);
+            Thread.Sleep(KeyHoldDelayMs);
+            keybd_event((byte)vk, 0, KEYEVENTF_KEYUP, 0);
+            logger.Info($"SendKeyPress: keybd_event fallback completed for vk=0x{vk:X2}");
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, $"SendKeyPress keybd_event fallback failed: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/src/OverlayPlugin/Models/OverlayShortcut.cs
+++ b/src/OverlayPlugin/Models/OverlayShortcut.cs
@@ -12,6 +12,7 @@ public sealed class OverlayShortcut : INotifyPropertyChanged
     private string command = string.Empty;
     private string arguments = string.Empty;
     private string hotkey = string.Empty;
+    private string mediaKeySelection = "PlayPause";
 
     public ShortcutActionType ActionType
     {
@@ -78,6 +79,19 @@ public sealed class OverlayShortcut : INotifyPropertyChanged
         }
     }
 
+    public string MediaKeySelection
+    {
+        get => mediaKeySelection;
+        set
+        {
+            if (mediaKeySelection != value)
+            {
+                mediaKeySelection = value;
+                OnPropertyChanged(nameof(MediaKeySelection));
+            }
+        }
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private void OnPropertyChanged(string propertyName)
@@ -99,5 +113,10 @@ public enum ShortcutActionType
     /// <summary>
     /// Simulate keyboard input (hotkey) using SendInput API.
     /// </summary>
-    SendInput
+    SendInput,
+    
+    /// <summary>
+    /// Send a media key (play/pause, volume, etc.).
+    /// </summary>
+    MediaKey
 }

--- a/src/OverlayPlugin/OverlayWindow.xaml.cs
+++ b/src/OverlayPlugin/OverlayWindow.xaml.cs
@@ -1375,6 +1375,13 @@ public partial class OverlayWindow : Window
                 return;
             }
 
+            if (shortcut.ActionType == ShortcutActionType.MediaKey)
+            {
+                logger.Info($"ExecuteShortcutAction: Sending media key '{shortcut.MediaKeySelection}'");
+                System.Threading.Tasks.Task.Run(() => NativeInput.SendMediaKey(shortcut.MediaKeySelection));
+                return;
+            }
+
             if (!string.IsNullOrWhiteSpace(shortcut.Command))
             {
                 var processStartInfo = new System.Diagnostics.ProcessStartInfo

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
@@ -173,6 +173,7 @@
                                                 <RowDefinition Height="Auto"/>
                                                 <RowDefinition Height="Auto"/>
                                                 <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
                                             </Grid.RowDefinitions>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="70"/>
@@ -193,6 +194,7 @@
                                                       Foreground="{DynamicResource TextBrush}">
                                                 <ComboBoxItem Content="CommandLine" Tag="{x:Static models:ShortcutActionType.CommandLine}"/>
                                                 <ComboBoxItem Content="SendInput" Tag="{x:Static models:ShortcutActionType.SendInput}"/>
+                                                <ComboBoxItem Content="MediaKey" Tag="{x:Static models:ShortcutActionType.MediaKey}"/>
                                             </ComboBox>
 
                                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Command:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"
@@ -237,7 +239,23 @@
                                                         Foreground="{DynamicResource TextBrush}"/>
                                             </Grid>
 
-                                            <Button Grid.Row="5" Grid.Column="2" Content="Delete"
+                                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Media Key:" VerticalAlignment="Center" Foreground="{DynamicResource TextBrush}"
+                                                       Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.MediaKey}}"/>
+                                            <ComboBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,6"
+                                                      SelectedValuePath="Tag"
+                                                      SelectedValue="{Binding MediaKeySelection}"
+                                                      Foreground="{DynamicResource TextBrush}"
+                                                      Visibility="{Binding ActionType, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter={x:Static models:ShortcutActionType.MediaKey}}">
+                                                <ComboBoxItem Content="Play/Pause" Tag="PlayPause"/>
+                                                <ComboBoxItem Content="Stop" Tag="Stop"/>
+                                                <ComboBoxItem Content="Next Track" Tag="NextTrack"/>
+                                                <ComboBoxItem Content="Previous Track" Tag="PreviousTrack"/>
+                                                <ComboBoxItem Content="Volume Up" Tag="VolumeUp"/>
+                                                <ComboBoxItem Content="Volume Down" Tag="VolumeDown"/>
+                                                <ComboBoxItem Content="Mute" Tag="Mute"/>
+                                            </ComboBox>
+
+                                            <Button Grid.Row="6" Grid.Column="2" Content="Delete"
                                                     MinWidth="70" HorizontalAlignment="Right"
                                                     Click="ShortcutDelete_Click"
                                                     Tag="{Binding}"


### PR DESCRIPTION
## Summary
- Add `MediaKey` action type to shortcuts, allowing users to send media keys (play/pause, volume, track navigation) from overlay shortcut buttons
- Uses Windows `SendInput` API with fallback to `keybd_event` for compatibility

## Changes
- **OverlayShortcut.cs**: Added `MediaKey` to `ShortcutActionType` enum and `MediaKeySelection` property
- **NativeInput.cs**: Added `SendMediaKey()` method with VK codes for 7 media keys
- **OverlaySettingsView.xaml**: Added MediaKey action option with dropdown for key selection
- **OverlayWindow.xaml.cs**: Updated `ExecuteShortcutAction()` to handle MediaKey type

## Available Media Keys
- Play/Pause
- Stop
- Next Track
- Previous Track
- Volume Up
- Volume Down
- Mute

## Usage
1. Go to Settings → Shortcuts
2. Add a new shortcut
3. Set Action to "MediaKey"
4. Select desired media key from dropdown
5. Click shortcut in overlay to send media key