### PR TITLE
feat(controller): add diagnostic logging and controller test tool

### DIFF
--- a/src/OverlayPlugin/Input/InputListener.cs
+++ b/src/OverlayPlugin/Input/InputListener.cs
@@ -171,17 +171,19 @@ internal sealed class InputListener
     /// </summary>
     public void StartController()
     {
-        // Initialize SDL2 if not already done
         if (!SDL2.Init())
         {
             logger.Error("Failed to initialize SDL2 for controller input");
             return;
         }
 
-        // Scan for already-connected controllers
         ScanForControllers();
 
-        pollTimer ??= new Timer(_ => PollControllers(), null, 0, PollIntervalMs);
+        if (pollTimer == null)
+        {
+            pollTimer = new Timer(_ => PollControllers(), null, 0, PollIntervalMs);
+            logger.Info($"Controller polling started (interval={PollIntervalMs}ms, combo=\"{controllerCombo}\").");
+        }
     }
 
     /// <summary>
@@ -192,9 +194,9 @@ internal sealed class InputListener
         pollTimer?.Dispose();
         pollTimer = null;
 
-        // Close all open controllers
         lock (controllersLock)
         {
+            logger.Info($"Controller polling stopped. Closing {controllers.Count} controller(s).");
             foreach (var controller in controllers)
             {
                 SDL2.GameControllerClose(controller.Handle);
@@ -243,11 +245,17 @@ internal sealed class InputListener
         lock (controllersLock)
         {
             var numJoysticks = SDL2.NumJoysticks();
+            logger.Info($"Controller scan: {numJoysticks} joystick(s) reported by SDL2.");
             for (int i = 0; i < numJoysticks; i++)
             {
                 if (SDL2.IsGameController(i))
                 {
                     AddController(i);
+                }
+                else
+                {
+                    var name = SDL2.JoystickNameForIndex(i) ?? $"Unknown {i}";
+                    logger.Debug($"Controller scan: Device {i} \"{name}\" is not a recognized GameController (no mapping).");
                 }
             }
         }
@@ -258,13 +266,14 @@ internal sealed class InputListener
         var handle = SDL2.GameControllerOpen(joystickIndex);
         if (handle == IntPtr.Zero)
         {
+            var name = SDL2.JoystickNameForIndex(joystickIndex) ?? $"Device {joystickIndex}";
+            logger.Warn($"Controller: Failed to open GameController for index {joystickIndex} (\"{name}\"). SDL2.GameControllerOpen returned null.");
             return;
         }
 
         var instanceId = SDL2.GameControllerGetJoystickInstanceID(handle);
-        var name = SDL2.GameControllerName(handle) ?? $"Controller {instanceId}";
+        var name2 = SDL2.GameControllerName(handle) ?? $"Controller {instanceId}";
 
-        // Check if we already have this controller
         lock (controllersLock)
         {
             if (controllers.Exists(c => c.InstanceId == instanceId))
@@ -273,8 +282,9 @@ internal sealed class InputListener
                 return;
             }
 
-            var controller = new LoadedController(handle, instanceId, name);
+            var controller = new LoadedController(handle, instanceId, name2);
             controllers.Add(controller);
+            logger.Info($"Controller: Opened \"{name2}\" (instanceId={instanceId}, joystickIndex={joystickIndex}).");
         }
     }
 
@@ -287,6 +297,7 @@ internal sealed class InputListener
                 var controller = controllers[i];
                 if (controller.InstanceId == instanceId)
                 {
+                    logger.Info($"Controller: Removed \"{controller.Name}\" (instanceId={instanceId}).");
                     SDL2.GameControllerClose(controller.Handle);
                     controllers.RemoveAt(i);
                     consumedNavigationButtons.Remove(instanceId);
@@ -403,6 +414,7 @@ internal sealed class InputListener
                 if (elapsed >= ToggleCooldownMs)
                 {
                     lastToggleTime = DateTime.Now;
+                    logger.Info($"Controller: Toggle combo \"{controllerCombo}\" detected from \"{controller.Name}\" (instanceId={controller.InstanceId}).");
                     TriggerToggle();
                 }
             }

--- a/src/OverlayPlugin/Interop/SDL2.cs
+++ b/src/OverlayPlugin/Interop/SDL2.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using Playnite.SDK;
 
 namespace PlayniteOverlay;
 
@@ -10,6 +11,7 @@ namespace PlayniteOverlay;
 internal static class SDL2
 {
     private const string SDL2_DLL = "SDL2.dll";
+    private static readonly ILogger logger = LogManager.GetLogger();
     private static bool isInitialized = false;
     private static bool initFailed = false;
 
@@ -86,30 +88,62 @@ internal static class SDL2
 
         try
         {
-            // Initialize joystick and gamecontroller subsystems
+            var assemblyLocation = typeof(SDL2).Assembly.Location;
+            var assemblyDir = System.IO.Path.GetDirectoryName(assemblyLocation) ?? "";
+            var mappingsPath = System.IO.Path.Combine(assemblyDir, "gamecontrollerdb.txt");
+
+            if (!System.IO.File.Exists(mappingsPath))
+            {
+                logger.Warn($"SDL2: gamecontrollerdb.txt not found at {mappingsPath}. Controller mappings will use SDL2 built-in defaults only.");
+            }
+
             var result = SDL_InitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS);
             if (result < 0)
             {
                 initFailed = true;
+                logger.Error($"SDL2: SDL_InitSubSystem failed with result {result}. Controller input will not work.");
                 return false;
             }
 
-            // Load controller mappings from the file next to the DLL
-            var assemblyLocation = typeof(SDL2).Assembly.Location;
-            var assemblyDir = System.IO.Path.GetDirectoryName(assemblyLocation) ?? "";
-            var mappingsPath = System.IO.Path.Combine(assemblyDir, "gamecontrollerdb.txt");
-            
             if (System.IO.File.Exists(mappingsPath))
             {
-                SDL_GameControllerAddMappingsFromFile(mappingsPath);
+                var mappingsLoaded = SDL_GameControllerAddMappingsFromFile(mappingsPath);
+                logger.Info($"SDL2: Initialized successfully. Loaded {mappingsLoaded} controller mappings from gamecontrollerdb.txt.");
+            }
+            else
+            {
+                logger.Info("SDL2: Initialized successfully using built-in controller mappings only.");
+            }
+
+            var joystickCount = SDL_NumJoysticks();
+            logger.Info($"SDL2: {joystickCount} joystick(s) detected at startup.");
+            for (int i = 0; i < joystickCount; i++)
+            {
+                var isGC = SDL_IsGameController(i) == SDL_TRUE;
+                var name = JoystickNameForIndex(i) ?? $"Unknown device {i}";
+                var mapping = GameControllerMappingForDeviceIndex(i);
+                logger.Info($"SDL2: Device {i}: \"{name}\" | IsGameController={isGC} | HasMapping={mapping != null}");
             }
 
             isInitialized = true;
             return true;
         }
-        catch (Exception)
+        catch (DllNotFoundException ex)
         {
             initFailed = true;
+            logger.Error(ex, $"SDL2: Failed to load {SDL2_DLL}. The native library is missing from the plugin directory. Controller input will not work.");
+            return false;
+        }
+        catch (BadImageFormatException ex)
+        {
+            initFailed = true;
+            logger.Error(ex, $"SDL2: {SDL2_DLL} architecture mismatch. The DLL may be x86/x64 incompatible with this Playnite instance. Controller input will not work.");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            initFailed = true;
+            logger.Error(ex, "SDL2: Unexpected error during initialization. Controller input will not work.");
             return false;
         }
     }
@@ -254,6 +288,111 @@ internal static class SDL2
     public static bool PollEvent(out SDL_Event _event)
     {
         return SDL_PollEvent(out _event) == 1;
+    }
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr SDL_JoystickNameForIndex(int deviceIndex);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr SDL_JoystickOpen(int deviceIndex);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern void SDL_JoystickClose(IntPtr joystick);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int SDL_JoystickNumButtons(IntPtr joystick);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int SDL_JoystickGetButton(IntPtr joystick, int button);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int SDL_JoystickNumAxes(IntPtr joystick);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern short SDL_JoystickGetAxis(IntPtr joystick, int axis);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr SDL_GameControllerMappingForDeviceIndex(int deviceIndex);
+
+    [DllImport(SDL2_DLL, CallingConvention = CallingConvention.Cdecl)]
+    private static extern void SDL_JoystickUpdate();
+
+    /// <summary>
+    /// Gets the joystick name for a device index (does not require opening).
+    /// </summary>
+    public static string? JoystickNameForIndex(int deviceIndex)
+    {
+        var ptr = SDL_JoystickNameForIndex(deviceIndex);
+        return ptr != IntPtr.Zero ? Marshal.PtrToStringAnsi(ptr) : null;
+    }
+
+    /// <summary>
+    /// Opens a raw joystick (for diagnostics when no GameController mapping exists).
+    /// </summary>
+    public static IntPtr JoystickOpen(int deviceIndex)
+    {
+        return SDL_JoystickOpen(deviceIndex);
+    }
+
+    /// <summary>
+    /// Closes a raw joystick handle.
+    /// </summary>
+    public static void JoystickClose(IntPtr joystick)
+    {
+        if (joystick != IntPtr.Zero)
+        {
+            SDL_JoystickClose(joystick);
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of buttons on a raw joystick.
+    /// </summary>
+    public static int JoystickNumButtons(IntPtr joystick)
+    {
+        return SDL_JoystickNumButtons(joystick);
+    }
+
+    /// <summary>
+    /// Gets the state of a raw joystick button (1 = pressed, 0 = released).
+    /// </summary>
+    public static int JoystickGetButton(IntPtr joystick, int button)
+    {
+        return SDL_JoystickGetButton(joystick, button);
+    }
+
+    /// <summary>
+    /// Gets the number of axes on a raw joystick.
+    /// </summary>
+    public static int JoystickNumAxes(IntPtr joystick)
+    {
+        return SDL_JoystickNumAxes(joystick);
+    }
+
+    /// <summary>
+    /// Gets the state of a raw joystick axis (-32768 to 32767).
+    /// </summary>
+    public static short JoystickGetAxis(IntPtr joystick, int axis)
+    {
+        return SDL_JoystickGetAxis(joystick, axis);
+    }
+
+    /// <summary>
+    /// Gets the mapping string for a controller device index.
+    /// Returns null if no mapping exists.
+    /// </summary>
+    public static string? GameControllerMappingForDeviceIndex(int deviceIndex)
+    {
+        var ptr = SDL_GameControllerMappingForDeviceIndex(deviceIndex);
+        return ptr != IntPtr.Zero ? Marshal.PtrToStringAnsi(ptr) : null;
+    }
+
+    /// <summary>
+    /// Updates the state of all open joysticks (raw).
+    /// </summary>
+    public static void JoystickUpdate()
+    {
+        SDL_JoystickUpdate();
     }
 
     #endregion

--- a/src/OverlayPlugin/Services/ControllerDiagnosticService.cs
+++ b/src/OverlayPlugin/Services/ControllerDiagnosticService.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using MVVM = CommunityToolkit.Mvvm.ComponentModel;
+using Playnite.SDK;
+
+namespace PlayniteOverlay.Services;
+
+internal sealed class ControllerDiagnosticService : MVVM.ObservableObject, IDisposable
+{
+    private static readonly ILogger logger = LogManager.GetLogger();
+
+    private System.Threading.Timer? pollTimer;
+    private bool isPolling;
+
+    public bool IsPolling
+    {
+        get => isPolling;
+        private set => SetProperty(ref isPolling, value);
+    }
+
+    public string StatusText
+    {
+        get => statusText;
+        private set => SetProperty(ref statusText, value);
+    }
+
+    public List<DiagnosticDevice> Devices
+    {
+        get => devices;
+        private set => SetProperty(ref devices, value);
+    }
+
+    private string statusText = string.Empty;
+    private List<DiagnosticDevice> devices = new List<DiagnosticDevice>();
+
+    public void StartPolling()
+    {
+        if (isPolling) return;
+
+        if (!SDL2.Init())
+        {
+            StatusText = "SDL2 failed to initialize. Check Playnite logs for details.";
+            return;
+        }
+
+        isPolling = true;
+        pollTimer = new System.Threading.Timer(_ => Poll(), null, 0, 200);
+        logger.Info("Controller diagnostic polling started.");
+    }
+
+    public void StopPolling()
+    {
+        if (!isPolling) return;
+
+        pollTimer?.Dispose();
+        pollTimer = null;
+        isPolling = false;
+        StatusText = string.Empty;
+        Devices = new List<DiagnosticDevice>();
+        logger.Info("Controller diagnostic polling stopped.");
+    }
+
+    private void Poll()
+    {
+        try
+        {
+            SDL2.GameControllerUpdate();
+            SDL2.JoystickUpdate();
+
+            var newDevices = new List<DiagnosticDevice>();
+            var numJoysticks = SDL2.NumJoysticks();
+
+            for (int i = 0; i < numJoysticks; i++)
+            {
+                var name = SDL2.JoystickNameForIndex(i) ?? $"Unknown device {i}";
+                var isGameController = SDL2.IsGameController(i);
+                var hasMapping = SDL2.GameControllerMappingForDeviceIndex(i) != null;
+
+                IntPtr handle;
+                bool usingGameController;
+                if (isGameController)
+                {
+                    handle = SDL2.GameControllerOpen(i);
+                    usingGameController = true;
+                }
+                else
+                {
+                    handle = SDL2.JoystickOpen(i);
+                    usingGameController = false;
+                }
+
+                var buttons = new List<DiagnosticButton>();
+
+                if (handle != IntPtr.Zero)
+                {
+                    if (usingGameController)
+                    {
+                        foreach (var btn in GameControllerButtonNames)
+                        {
+                            var pressed = SDL2.GameControllerGetButton(handle, btn.Key) == 1;
+                            buttons.Add(new DiagnosticButton(btn.Value, pressed));
+                        }
+                    }
+                    else
+                    {
+                        var numButtons = SDL2.JoystickNumButtons(handle);
+                        for (int b = 0; b < Math.Min(numButtons, 20); b++)
+                        {
+                            var pressed = SDL2.JoystickGetButton(handle, b) == 1;
+                            buttons.Add(new DiagnosticButton($"Button {b}", pressed));
+                        }
+                    }
+
+                    if (usingGameController)
+                    {
+                        SDL2.GameControllerClose(handle);
+                    }
+                    else
+                    {
+                        SDL2.JoystickClose(handle);
+                    }
+                }
+
+                newDevices.Add(new DiagnosticDevice(name, isGameController, hasMapping, buttons));
+            }
+
+            Devices = newDevices;
+            StatusText = numJoysticks == 0
+                ? "No joysticks/controllers detected. Connect a controller and press buttons."
+                : $"{numJoysticks} device(s) found. Press buttons to verify input.";
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Controller diagnostic poll error.");
+        }
+    }
+
+    private static readonly Dictionary<int, string> GameControllerButtonNames = new Dictionary<int, string>
+    {
+        { SDL2.SDL_CONTROLLER_BUTTON_A, "A" },
+        { SDL2.SDL_CONTROLLER_BUTTON_B, "B" },
+        { SDL2.SDL_CONTROLLER_BUTTON_X, "X" },
+        { SDL2.SDL_CONTROLLER_BUTTON_Y, "Y" },
+        { SDL2.SDL_CONTROLLER_BUTTON_BACK, "Back" },
+        { SDL2.SDL_CONTROLLER_BUTTON_GUIDE, "Guide" },
+        { SDL2.SDL_CONTROLLER_BUTTON_START, "Start" },
+        { SDL2.SDL_CONTROLLER_BUTTON_LEFTSTICK, "L.Stick" },
+        { SDL2.SDL_CONTROLLER_BUTTON_RIGHTSTICK, "R.Stick" },
+        { SDL2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER, "LB" },
+        { SDL2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, "RB" },
+        { SDL2.SDL_CONTROLLER_BUTTON_DPAD_UP, "D.Up" },
+        { SDL2.SDL_CONTROLLER_BUTTON_DPAD_DOWN, "D.Down" },
+        { SDL2.SDL_CONTROLLER_BUTTON_DPAD_LEFT, "D.Left" },
+        { SDL2.SDL_CONTROLLER_BUTTON_DPAD_RIGHT, "D.Right" },
+    };
+
+    public void Dispose()
+    {
+        StopPolling();
+    }
+}
+
+internal sealed class DiagnosticDevice
+{
+    public string Name { get; }
+    public bool IsGameController { get; }
+    public bool HasMapping { get; }
+    public List<DiagnosticButton> Buttons { get; }
+
+    public DiagnosticDevice(string name, bool isGameController, bool hasMapping, List<DiagnosticButton> buttons)
+    {
+        Name = name;
+        IsGameController = isGameController;
+        HasMapping = hasMapping;
+        Buttons = buttons;
+    }
+}
+
+internal sealed class DiagnosticButton
+{
+    public string Name { get; }
+    public bool IsPressed { get; }
+
+    public DiagnosticButton(string name, bool isPressed)
+    {
+        Name = name;
+        IsPressed = isPressed;
+    }
+}

--- a/src/OverlayPlugin/Services/ControllerDiagnosticService.cs
+++ b/src/OverlayPlugin/Services/ControllerDiagnosticService.cs
@@ -5,7 +5,7 @@ using Playnite.SDK;
 
 namespace PlayniteOverlay.Services;
 
-internal sealed class ControllerDiagnosticService : MVVM.ObservableObject, IDisposable
+public sealed class ControllerDiagnosticService : MVVM.ObservableObject, IDisposable
 {
     private static readonly ILogger logger = LogManager.GetLogger();
 
@@ -160,7 +160,7 @@ internal sealed class ControllerDiagnosticService : MVVM.ObservableObject, IDisp
     }
 }
 
-internal sealed class DiagnosticDevice
+public sealed class DiagnosticDevice
 {
     public string Name { get; }
     public bool IsGameController { get; }
@@ -176,7 +176,7 @@ internal sealed class DiagnosticDevice
     }
 }
 
-internal sealed class DiagnosticButton
+public sealed class DiagnosticButton
 {
     public string Name { get; }
     public bool IsPressed { get; }

--- a/src/OverlayPlugin/Services/ControllerDiagnosticView.xaml
+++ b/src/OverlayPlugin/Services/ControllerDiagnosticView.xaml
@@ -1,0 +1,69 @@
+<UserControl x:Class="PlayniteOverlay.ControllerDiagnosticView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:PlayniteOverlay"
+             mc:Ignorable="d"
+             d:DesignWidth="500" d:DesignHeight="300">
+    <UserControl.Resources>
+        <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <local:InvertedBoolToVisibilityConverter x:Key="InvertedBoolToVisibilityConverter"/>
+        <local:BoolToColorConverter x:Key="BoolToColorConverter"/>
+        <local:ButtonStateConverter x:Key="ButtonStateConverter"/>
+        <local:ButtonTextConverter x:Key="ButtonTextConverter"/>
+    </UserControl.Resources>
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+            <Button x:Name="ToggleBtn" Content="Start Diagnostic" Padding="12,4" Click="ToggleDiagnostic_Click"/>
+            <TextBlock x:Name="StatusText" Text="" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="Gray"/>
+        </StackPanel>
+
+        <ItemsControl Grid.Row="2" x:Name="DevicesList">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="#2A2A2A" CornerRadius="6" Padding="10" Margin="0,0,0,8">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="White"/>
+                                <Border Margin="8,0,0,0" Padding="4,1" CornerRadius="3"
+                                        Background="{Binding IsGameController, Converter={StaticResource BoolToColorConverter}}"
+                                        Visibility="{Binding IsGameController, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <TextBlock Text="GameController" FontSize="10" Foreground="White"/>
+                                </Border>
+                                <Border Margin="4,0,0,0" Padding="4,1" CornerRadius="3"
+                                        Background="{Binding HasMapping, Converter={StaticResource BoolToColorConverter}}"
+                                        Visibility="{Binding HasMapping, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <TextBlock Text="Has Mapping" FontSize="10" Foreground="White"/>
+                                </Border>
+                                <TextBlock Margin="8,0,0,0" Foreground="#FF6666" FontSize="11"
+                                           Visibility="{Binding IsGameController, Converter={StaticResource InvertedBoolToVisibilityConverter}}">
+                                    <Run Text="⚠ Not recognized as GameController"/>
+                                </TextBlock>
+                            </StackPanel>
+                            <WrapPanel Margin="0,4,0,0">
+                                <ItemsControl ItemsSource="{Binding Buttons}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Margin="0,0,4,4" Padding="6,3" CornerRadius="4"
+                                                    Background="{Binding IsPressed, Converter={StaticResource ButtonStateConverter}}">
+                                                <TextBlock Text="{Binding Name}" FontSize="11"
+                                                           Foreground="{Binding IsPressed, Converter={StaticResource ButtonTextConverter}}"/>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </WrapPanel>
+                        </StackPanel>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Grid>
+</UserControl>

--- a/src/OverlayPlugin/Services/ControllerDiagnosticView.xaml.cs
+++ b/src/OverlayPlugin/Services/ControllerDiagnosticView.xaml.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using PlayniteOverlay.Services;
+
+namespace PlayniteOverlay;
+
+public partial class ControllerDiagnosticView : UserControl
+{
+    private readonly ControllerDiagnosticService diagnosticService;
+
+    public ControllerDiagnosticView(ControllerDiagnosticService diagnosticService)
+    {
+        this.diagnosticService = diagnosticService ?? throw new ArgumentNullException(nameof(diagnosticService));
+        InitializeComponent();
+        DevicesList.ItemsSource = diagnosticService.Devices;
+
+        diagnosticService.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ControllerDiagnosticService.Devices))
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    DevicesList.ItemsSource = diagnosticService.Devices;
+                }));
+            }
+            else if (e.PropertyName == nameof(ControllerDiagnosticService.StatusText))
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    StatusText.Text = diagnosticService.StatusText;
+                }));
+            }
+        };
+    }
+
+    private void ToggleDiagnostic_Click(object sender, RoutedEventArgs e)
+    {
+        if (diagnosticService.IsPolling)
+        {
+            diagnosticService.StopPolling();
+            ToggleBtn.Content = "Start Diagnostic";
+        }
+        else
+        {
+            diagnosticService.StartPolling();
+            ToggleBtn.Content = "Stop Diagnostic";
+        }
+    }
+
+    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    {
+        base.OnVisualParentChanged(oldParent);
+        if (oldParent != null && VisualParent == null)
+        {
+            diagnosticService.StopPolling();
+        }
+    }
+}
+
+internal class BoolToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is true ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+internal class InvertedBoolToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is false ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+internal class BoolToColorConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is true
+            ? new SolidColorBrush(Color.FromArgb(200, 76, 175, 80))
+            : new SolidColorBrush(Color.FromArgb(200, 200, 60, 60));
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+internal class ButtonStateConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is true
+            ? new SolidColorBrush(Color.FromArgb(220, 76, 175, 80))
+            : new SolidColorBrush(Color.FromArgb(220, 60, 60, 60));
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+internal class ButtonTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is true
+            ? new SolidColorBrush(Colors.White)
+            : new SolidColorBrush(Color.FromArgb(200, 180, 180, 180));
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml
@@ -59,6 +59,7 @@
                     <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
                                Foreground="Gray"
                                Text="Note: Controller detection uses SDL2 and supports Xbox, PlayStation, Nintendo, and most other controllers."/>
+                    <ContentControl x:Name="DiagnosticHost" Margin="0,8,0,0"/>
                 </StackPanel>
             </GroupBox>
 

--- a/src/OverlayPlugin/Settings/OverlaySettingsView.xaml.cs
+++ b/src/OverlayPlugin/Settings/OverlaySettingsView.xaml.cs
@@ -3,20 +3,25 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using PlayniteOverlay.Models;
+using PlayniteOverlay.Services;
 
 namespace PlayniteOverlay;
 
 public partial class OverlaySettingsView : UserControl
 {
+    private readonly ControllerDiagnosticService diagnosticService;
+
     public OverlaySettingsView()
     {
         InitializeComponent();
         Loaded += OverlaySettingsView_Loaded;
+        diagnosticService = new ControllerDiagnosticService();
     }
 
     private void OverlaySettingsView_Loaded(object sender, RoutedEventArgs e)
     {
         UpdateAddButtonState();
+        DiagnosticHost.Content = new ControllerDiagnosticView(diagnosticService);
     }
 
     private OverlaySettings? Model => (DataContext as OverlaySettingsViewModel)?.Settings;


### PR DESCRIPTION
## Summary

Addresses #47 by adding comprehensive controller diagnostic logging and an interactive test tool to help users and developers troubleshoot controller input issues.

## Problem

Issue #47 reports controller input not working with Xbox One + REWASD. The existing code had **zero diagnostic logging** — when controller input silently failed, there was no way to determine why (SDL2 DLL missing? Architecture mismatch? No mapping for virtual controller? Init failed?).

## Changes

### Comprehensive SDL2 Logging (`SDL2.cs`)
- **Init**: Logs success/failure with specific exception types (`DllNotFoundException`, `BadImageFormatException`, generic)
- **Startup scan**: Logs all detected joysticks with name, `IsGameController` status, and mapping presence
- **Mappings**: Logs how many mappings loaded from `gamecontrollerdb.txt`, warns if file is missing
- These logs go to the standard Playnite log, accessible to all users

### InputListener Logging (`InputListener.cs`)
- **Scan**: Logs joystick count and which devices are/aren't recognized as GameController
- **Controller open/close**: Logs device name and instance ID on connect/disconnect
- **Toggle detection**: Logs which controller triggered the toggle combo
- **Polling lifecycle**: Logs start/stop with interval and current combo

### Controller Diagnostic Tool (new)
- **`ControllerDiagnosticService`**: Polls SDL2 every 200ms, reads all device states, exposes them as Observable properties
- **`ControllerDiagnosticView`**: WPF control embedded in Settings → Controller section with:
  - Start/Stop button
  - Per-device info: name, IsGameController badge, HasMapping badge
  - ⚠ warning for devices not recognized as GameController
  - Real-time button state grid (green = pressed, dark = released)
  - **Raw joystick fallback**: For devices without GameController mappings (e.g., REWASD virtual controllers), falls back to raw joystick button reading so users can still verify input

## How to Test

1. Build and install the plugin
2. Open Playnite → Add-ons → Extension settings → Playnite Overlay
3. Scroll to the Controller section
4. Click "Start Diagnostic"
5. Connect a controller and press buttons — they should light up green
6. Check Playnite logs for SDL2 initialization details

## Next Steps (follow-up PRs)

- Add raw joystick fallback in `InputListener` for unmapped devices (so REWASD controllers work)
- Add controller GUID display in diagnostic tool for precise device identification
- Reduce polling interval from 100ms to ~16ms for better responsiveness

Ref #47